### PR TITLE
Fixed minor bugs in data science scenario.

### DIFF
--- a/docs-samples/data-science/data-science-tutorial/01-ingest-data-into-fabric-lakehouse-using-apache-spark.ipynb
+++ b/docs-samples/data-science/data-science-tutorial/01-ingest-data-into-fabric-lakehouse-using-apache-spark.ipynb
@@ -348,17 +348,6 @@
         "synapse_widget": {
             "version": "0.1",
             "state": {}
-        },
-        "trident": {
-            "lakehouse": {
-                "default_lakehouse": "4fd9d516-62ef-4c40-9edf-b64bc782ca80",
-                "known_lakehouses": [{
-                        "id": "4fd9d516-62ef-4c40-9edf-b64bc782ca80"
-                    }
-                ],
-                "default_lakehouse_name": "DefaultLH",
-                "default_lakehouse_workspace_id": "c43639aa-073c-4b8b-987b-2110918da2c5"
-            }
         }
     },
     "nbformat": 4,

--- a/docs-samples/data-science/data-science-tutorial/02-explore-and-visualize-data-using-notebooks.ipynb
+++ b/docs-samples/data-science/data-science-tutorial/02-explore-and-visualize-data-using-notebooks.ipynb
@@ -748,17 +748,6 @@
         "synapse_widget": {
             "version": "0.1",
             "state": {}
-        },
-        "trident": {
-            "lakehouse": {
-                "default_lakehouse": "4fd9d516-62ef-4c40-9edf-b64bc782ca80",
-                "known_lakehouses": [{
-                        "id": "4fd9d516-62ef-4c40-9edf-b64bc782ca80"
-                    }
-                ],
-                "default_lakehouse_name": "DefaultLH",
-                "default_lakehouse_workspace_id": "c43639aa-073c-4b8b-987b-2110918da2c5"
-            }
         }
     },
     "nbformat": 4,

--- a/docs-samples/data-science/data-science-tutorial/03-perform-data-cleansing-and-preparation-using-apache-spark.ipynb
+++ b/docs-samples/data-science/data-science-tutorial/03-perform-data-cleansing-and-preparation-using-apache-spark.ipynb
@@ -816,17 +816,6 @@
                     }
                 }
             }
-        },
-        "trident": {
-            "lakehouse": {
-                "default_lakehouse": "4fd9d516-62ef-4c40-9edf-b64bc782ca80",
-                "known_lakehouses": [{
-                        "id": "4fd9d516-62ef-4c40-9edf-b64bc782ca80"
-                    }
-                ],
-                "default_lakehouse_name": "DefaultLH",
-                "default_lakehouse_workspace_id": "c43639aa-073c-4b8b-987b-2110918da2c5"
-            }
         }
     },
     "nbformat": 4,

--- a/docs-samples/data-science/data-science-tutorial/04-train-and-track-machine-learning-models.ipynb
+++ b/docs-samples/data-science/data-science-tutorial/04-train-and-track-machine-learning-models.ipynb
@@ -1,1666 +1,2169 @@
 {
-    "cells": [{
+    "cells": [
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["# Module 4: Train and register a machine learning model\r\n", "In this module you will learn to train a machine learning model to predict the total ride duration (tripDuration) of yellow taxi trips in New York City based on various factors such as pickup and drop-off locations, distance, date, time, number of passengers, and rate code.\r\n", "\r\n", "Once a model is trained, you will learn to register the trained model, and log hyperaparameters used and evaluation metrics using Trident's native integration with the MLflow framework.\r\n", "\r\n", "[MLflow](https://mlflow.org/docs/latest/index.html) is an open source platform for managing the machine learning lifecycle with features like Tracking, Models, and Model Registry. MLflow is natively integrated with Trident Data Science Experience."],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "# Module 4: Train and register a machine learning model\n",
+                "In this module you will learn to train a machine learning model to predict the total ride duration (tripDuration) of yellow taxi trips in New York City based on various factors such as pickup and drop-off locations, distance, date, time, number of passengers, and rate code.\n",
+                "\n",
+                "Once a model is trained, you will learn to register the trained model, and log hyperaparameters used and evaluation metrics using Trident's native integration with the MLflow framework.\n",
+                "\n",
+                "[MLflow](https://mlflow.org/docs/latest/index.html) is an open source platform for managing the machine learning lifecycle with features like Tracking, Models, and Model Registry. MLflow is natively integrated with Trident Data Science Experience."
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["Please add the lakehouse you created earlier as the default lakehouse in this notebook."],
             "metadata": {
                 "nteract": {
                     "transient": {
                         "deleting": false
                     }
                 }
-            }
-        }, {
+            },
+            "source": [
+                "Please add the lakehouse you created earlier as the default lakehouse in this notebook."
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Import mlflow and create an experiment to log the run"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Import mlflow and create an experiment to log the run"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["# Create Experiment to Track and register model with mlflow\r\n", "import mlflow\r\n", "print(f\"mlflow lbrary version: {mlflow.__version__}\")\r\n", "EXPERIMENT_NAME = \"nyctaxi_tripduration\"\r\n", "mlflow.set_experiment(EXPERIMENT_NAME)"],
-            "outputs": [{
-                    "output_type": "display_data",
-                    "data": {
-                        "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 3,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3635782Z",
-                            "session_start_time": "2023-05-08T06:54:40.9503133Z",
-                            "execution_start_time": "2023-05-08T06:54:50.409838Z",
-                            "execution_finish_time": "2023-05-08T06:55:13.7919158Z",
-                            "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 0,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [],
-                                "limit": 20,
-                                "rule": "ALL_DESC"
-                            },
-                            "parent_msg_id": "4a87035d-eb66-4a9e-ac6a-e996598bf69d"
-                        },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 3, Finished, Available)"
-                    },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
-                    "name": "stdout",
-                    "text": ["mlflow lbrary version: 2.1.1\n"]
-                }, {
-                    "output_type": "stream",
-                    "name": "stderr",
-                    "text": ["2023/05/08 06:54:53 INFO mlflow.tracking.fluent: Experiment with name 'nyctaxi_tripduration' does not exist. Creating a new experiment.\n"]
-                }, {
-                    "output_type": "execute_result",
-                    "execution_count": 6,
-                    "data": {
-                        "text/plain": "<Experiment: artifact_location='', creation_time=1683528903111, experiment_id='803a41bb-9147-4782-bb5b-ccbc239b6beb', last_update_time=None, lifecycle_stage='active', name='nyctaxi_tripduration', tags={}>"
-                    },
-                    "metadata": {}
-                }
-            ],
             "execution_count": 1,
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Read Cleansed data from lakehouse delta table (saved in module 3)"],
-            "metadata": {}
-        }, {
-            "cell_type": "code",
-            "source": ["SEED = 1234\r\n", "# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\r\n", "training_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED)"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 4,
-                            "state": "finished",
+                            "execution_finish_time": "2023-05-08T06:55:13.7919158Z",
+                            "execution_start_time": "2023-05-08T06:54:50.409838Z",
                             "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3679617Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:55:14.9123974Z",
-                            "execution_finish_time": "2023-05-08T06:55:20.2966986Z",
+                            "parent_msg_id": "4a87035d-eb66-4a9e-ac6a-e996598bf69d",
+                            "queued_time": "2023-05-08T06:54:40.3635782Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": "2023-05-08T06:54:40.9503133Z",
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 3,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 0,
-                                        "dataRead": 4880,
-                                        "rowCount": 50,
-                                        "jobId": 9,
-                                        "name": "toString at String.java:2994",
-                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
-                                        "submissionTime": "2023-05-08T06:55:19.615GMT",
-                                        "completionTime": "2023-05-08T06:55:19.661GMT",
-                                        "stageIds": [15, 13, 14],
-                                        "jobGroup": "4",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 52,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 51,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 2,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 4880,
-                                        "dataRead": 18035,
-                                        "rowCount": 66,
-                                        "jobId": 8,
-                                        "name": "toString at String.java:2994",
-                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
-                                        "submissionTime": "2023-05-08T06:55:18.869GMT",
-                                        "completionTime": "2023-05-08T06:55:19.583GMT",
-                                        "stageIds": [12, 11],
-                                        "jobGroup": "4",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 51,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 50,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 50,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 18035,
-                                        "dataRead": 31221,
-                                        "rowCount": 32,
-                                        "jobId": 7,
-                                        "name": "toString at String.java:2994",
-                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
-                                        "submissionTime": "2023-05-08T06:55:15.869GMT",
-                                        "completionTime": "2023-05-08T06:55:16.506GMT",
-                                        "stageIds": [10],
-                                        "jobGroup": "4",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }
-                                ],
+                                "jobs": [],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 0,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "dd763256-a2b1-49b7-bc58-ca2a125947da"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 3
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 4, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 3, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "mlflow lbrary version: 2.1.1\n"
+                    ]
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "2023/05/08 06:54:53 INFO mlflow.tracking.fluent: Experiment with name 'nyctaxi_tripduration' does not exist. Creating a new experiment.\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "<Experiment: artifact_location='', creation_time=1683528903111, experiment_id='803a41bb-9147-4782-bb5b-ccbc239b6beb', last_update_time=None, lifecycle_stage='active', name='nyctaxi_tripduration', tags={}>"
+                        ]
+                    },
+                    "execution_count": 6,
+                    "metadata": {},
+                    "output_type": "execute_result"
                 }
             ],
+            "source": [
+                "# Create Experiment to Track and register model with mlflow\n",
+                "import mlflow\n",
+                "print(f\"mlflow lbrary version: {mlflow.__version__}\")\n",
+                "EXPERIMENT_NAME = \"nyctaxi_tripduration\"\n",
+                "mlflow.set_experiment(EXPERIMENT_NAME)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Read Cleansed data from lakehouse delta table (saved in module 3)"
+            ]
+        },
+        {
+            "cell_type": "code",
             "execution_count": 2,
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Perform random split to get train and test datasets and define categorical and numeric features"],
-            "metadata": {}
-        }, {
-            "cell_type": "code",
-            "source": ["TRAIN_TEST_SPLIT = [0.75, 0.25]\r\n", "train_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\r\n", "\r\n", "# Cache the dataframes to improve the speed of repeatable reads\r\n", "train_df.cache()\r\n", "test_df.cache()\r\n", "\r\n", "print(f\"train set count:{train_df.count()}\")\r\n", "print(f\"test set count:{test_df.count()}\")\r\n", "\r\n", "categorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\r\n", "numeric_features = ['passengerCount', \"tripDistance\"]"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 5,
-                            "state": "finished",
+                            "execution_finish_time": "2023-05-08T06:55:20.2966986Z",
+                            "execution_start_time": "2023-05-08T06:55:14.9123974Z",
                             "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.368888Z",
+                            "parent_msg_id": "dd763256-a2b1-49b7-bc58-ca2a125947da",
+                            "queued_time": "2023-05-08T06:54:40.3679617Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
                             "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:55:21.4205521Z",
-                            "execution_finish_time": "2023-05-08T06:56:24.1891658Z",
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 6,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
+                                "jobs": [
+                                    {
+                                        "completionTime": "2023-05-08T06:55:19.661GMT",
+                                        "dataRead": 4880,
                                         "dataWritten": 0,
-                                        "dataRead": 767,
-                                        "rowCount": 13,
-                                        "jobId": 15,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
-                                        "submissionTime": "2023-05-08T06:56:23.086GMT",
-                                        "completionTime": "2023-05-08T06:56:23.103GMT",
-                                        "stageIds": [24, 25],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 14,
+                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
+                                        "jobGroup": "4",
+                                        "jobId": 9,
+                                        "killedTasksSummary": {},
+                                        "name": "toString at String.java:2994",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
                                         "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 767,
-                                        "dataRead": 1282332012,
-                                        "rowCount": 46031000,
-                                        "jobId": 14,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
-                                        "submissionTime": "2023-05-08T06:55:58.846GMT",
-                                        "completionTime": "2023-05-08T06:56:23.069GMT",
-                                        "stageIds": [23],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 13,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 767,
-                                        "rowCount": 13,
-                                        "jobId": 13,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
-                                        "submissionTime": "2023-05-08T06:55:58.662GMT",
-                                        "completionTime": "2023-05-08T06:55:58.700GMT",
-                                        "stageIds": [21, 22],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 14,
-                                        "numActiveTasks": 0,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 767,
-                                        "dataRead": 1282426207,
-                                        "rowCount": 46031000,
-                                        "jobId": 12,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
-                                        "submissionTime": "2023-05-08T06:55:22.354GMT",
-                                        "completionTime": "2023-05-08T06:55:58.642GMT",
-                                        "stageIds": [20],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 13,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
+                                        "numSkippedStages": 2,
+                                        "numSkippedTasks": 51,
+                                        "numTasks": 52,
+                                        "rowCount": 50,
+                                        "stageIds": [
+                                            15,
+                                            13,
+                                            14
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:19.615GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:19.583GMT",
+                                        "dataRead": 18035,
+                                        "dataWritten": 4880,
+                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
+                                        "jobGroup": "4",
+                                        "jobId": 8,
+                                        "killedTasksSummary": {},
+                                        "name": "toString at String.java:2994",
                                         "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 16086,
-                                        "rowCount": 15,
-                                        "jobId": 11,
-                                        "name": "$anonfun$recordDeltaOperationInternal$1 at SynapseLoggingShim.scala:95",
-                                        "description": "Delta: Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]: Filtering files for query",
-                                        "submissionTime": "2023-05-08T06:55:21.992GMT",
-                                        "completionTime": "2023-05-08T06:55:22.150GMT",
-                                        "stageIds": [19, 18],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 51,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 50,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
                                         "numCompletedIndices": 50,
-                                        "numActiveStages": 0,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 16086,
-                                        "rowCount": 15,
-                                        "jobId": 10,
-                                        "name": "$anonfun$recordDeltaOperationInternal$1 at SynapseLoggingShim.scala:95",
-                                        "description": "Delta: Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]: Filtering files for query",
-                                        "submissionTime": "2023-05-08T06:55:21.497GMT",
-                                        "completionTime": "2023-05-08T06:55:21.725GMT",
-                                        "stageIds": [16, 17],
-                                        "jobGroup": "5",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 51,
-                                        "numActiveTasks": 0,
                                         "numCompletedTasks": 50,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
                                         "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 50,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }
-                                ],
-                                "limit": 20,
-                                "rule": "ALL_DESC"
-                            },
-                            "parent_msg_id": "77df141c-597f-4288-a320-a29dd0492f77"
-                        },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 5, Finished, Available)"
-                    },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
-                    "name": "stdout",
-                    "text": ["train set count:17256796\ntest set count:5754996\n"]
-                }
-            ],
-            "execution_count": 3,
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Define the steps to perform additional feature engineering and train the model using Spark ML pipelines and Microsoft SynapseML library\r\n", "You can learn more about Spark ML pipelines [here](https://spark.apache.org/docs/latest/ml-pipeline.html), and SynapseML is documented [here](https://microsoft.github.io/SynapseML/docs/about/)\r\n", "\r\n", "The algorithm used for this tutorial, [LightGBM](https://lightgbm.readthedocs.io/en/v3.3.2/) is a fast, distributed, high performance gradient boosting framework based on decision tree algorithms. It is an open source project developed by Microsoft and supports regression, classification and many other machine learning scenarios. Its main advantages are faster training speed, lower memory usage, better accuracy, and support for distributed learning."],
-            "metadata": {}
-        }, {
-            "cell_type": "code",
-            "source": ["from pyspark.ml.feature import OneHotEncoder, VectorAssembler, StringIndexer\r\n", "from pyspark.ml import Pipeline\r\n", "from synapse.ml.core.platform import *\r\n", "from synapse.ml.lightgbm import LightGBMRegressor\r\n", "\r\n", "# Define a pipeline steps for training a LightGBMRegressor regressor model\r\n", "def lgbm_pipeline(categorical_features,numeric_features, hyperparameters):\r\n", "    # String indexer\r\n", "    stri = StringIndexer(inputCols=categorical_features, \r\n", "                        outputCols=[f\"{feat}Idx\" for feat in categorical_features]).setHandleInvalid(\"keep\")\r\n", "    # encode categorical/indexed columns\r\n", "    ohe = OneHotEncoder(inputCols= stri.getOutputCols(),  \r\n", "                        outputCols=[f\"{feat}Enc\" for feat in categorical_features])\r\n", "    \r\n", "    # convert all feature columns into a vector\r\n", "    featurizer = VectorAssembler(inputCols=ohe.getOutputCols() + numeric_features, outputCol=\"features\")\r\n", "\r\n", "    # Define the LightGBM regressor\r\n", "    lgr = LightGBMRegressor(\r\n", "        objective = hyperparameters[\"objective\"],\r\n", "        alpha = hyperparameters[\"alpha\"],\r\n", "        learningRate = hyperparameters[\"learning_rate\"],\r\n", "        numLeaves = hyperparameters[\"num_leaves\"],\r\n", "        labelCol=\"tripDuration\",\r\n", "        numIterations = hyperparameters[\"iterations\"],\r\n", "    )\r\n", "    # Define the steps and sequence of the SPark ML pipeline\r\n", "    ml_pipeline = Pipeline(stages=[stri, ohe, featurizer, lgr])\r\n", "    return ml_pipeline\r\n"],
-            "outputs": [{
-                    "output_type": "display_data",
-                    "data": {
-                        "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 6,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3758597Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:56:25.2625578Z",
-                            "execution_finish_time": "2023-05-08T06:56:25.6028613Z",
-                            "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 0,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [],
-                                "limit": 20,
-                                "rule": "ALL_DESC"
-                            },
-                            "parent_msg_id": "77d42f20-a644-4a19-8eda-aad67facb410"
-                        },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 6, Finished, Available)"
-                    },
-                    "metadata": {}
-                }
-            ],
-            "execution_count": 4,
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Define Training Hyperparameters\r\n", "Hyperparameters are the parameters that you can change to control how a machine learning model is trained. Hyperparameters can affect the speed, quality and accuracy of the model. Some common methods to find the best hyperparameters are by testing different values, using a grid or random search, or using a more advanced optimization technique.\r\n", "The hyperparameters for the lightgbm model in this tutorial have been pre-tuned using a distributed gridsearch run using [hyperopt](https://github.com/hyperopt/hyperopt)"],
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Model Run 1: Using default lightgbm hyperparameters"],
-            "metadata": {}
-        }, {
-            "cell_type": "code",
-            "source": ["# Default hyperparameters for LightGBM Model\r\n", "LGBM_PARAMS = {\"objective\":\"regression\",\r\n", "    \"alpha\":0.9,\r\n", "    \"learning_rate\":0.1,\r\n", "    \"num_leaves\":31,\r\n", "    \"iterations\":100}"],
-            "outputs": [{
-                    "output_type": "display_data",
-                    "data": {
-                        "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 7,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3769966Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:56:26.7476777Z",
-                            "execution_finish_time": "2023-05-08T06:56:27.103696Z",
-                            "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 0,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [],
-                                "limit": 20,
-                                "rule": "ALL_DESC"
-                            },
-                            "parent_msg_id": "b311354f-d27a-414f-bb32-8b775647d2a7"
-                        },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 7, Finished, Available)"
-                    },
-                    "metadata": {}
-                }
-            ],
-            "execution_count": 5,
-            "metadata": {}
-        }, {
-            "cell_type": "markdown",
-            "source": ["#### Fit the defined pipeline on the training dataframe and generate predictions on the test dataset"],
-            "metadata": {}
-        }, {
-            "cell_type": "code",
-            "source": ["if mlflow.active_run() is None:\r\n", "    mlflow.start_run()\r\n", "run = mlflow.active_run()\r\n", "print(f\"Active experiment run_id: {run.info.run_id}\")\r\n", "lg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\r\n", "lg_model = lg_pipeline.fit(train_df)\r\n", "\r\n", "# Get Predictions\r\n", "lg_predictions = lg_model.transform(test_df)\r\n", "## Caching predictions to run model evaluation faster\r\n", "lg_predictions.cache()\r\n", "print(f\"Prediction run for {lg_predictions.count()} samples\")"],
-            "outputs": [{
-                    "output_type": "display_data",
-                    "data": {
-                        "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 8,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3849016Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:56:28.2995355Z",
-                            "execution_finish_time": "2023-05-08T06:58:52.2672455Z",
-                            "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 6,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 0,
-                                        "dataRead": 767,
-                                        "rowCount": 13,
-                                        "jobId": 21,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:58:49.952GMT",
-                                        "completionTime": "2023-05-08T06:58:49.972GMT",
-                                        "stageIds": [33, 32],
-                                        "jobGroup": "8",
+                                        "numTasks": 51,
+                                        "rowCount": 66,
+                                        "stageIds": [
+                                            12,
+                                            11
+                                        ],
                                         "status": "SUCCEEDED",
-                                        "numTasks": 14,
+                                        "submissionTime": "2023-05-08T06:55:18.869GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:16.506GMT",
+                                        "dataRead": 31221,
+                                        "dataWritten": 18035,
+                                        "description": "Delta: Job group for statement 4:\nSEED = 1234\n# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\ntraining_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED): Compute snapshot for version: 0",
+                                        "jobGroup": "4",
+                                        "jobId": 7,
+                                        "killedTasksSummary": {},
+                                        "name": "toString at String.java:2994",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
                                         "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
+                                        "numCompletedTasks": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 767,
-                                        "dataRead": 714202176,
-                                        "rowCount": 595,
-                                        "jobId": 20,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:57:31.849GMT",
-                                        "completionTime": "2023-05-08T06:58:49.934GMT",
-                                        "stageIds": [31],
-                                        "jobGroup": "8",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 13,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 2140848048,
-                                        "rowCount": 1734,
-                                        "jobId": 19,
-                                        "name": "collect at LightGBMBase.scala:597",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:56:37.189GMT",
-                                        "completionTime": "2023-05-08T06:57:31.443GMT",
-                                        "stageIds": [30],
-                                        "jobGroup": "8",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 8,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 8,
                                         "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 8,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 207605448,
-                                        "rowCount": 1,
-                                        "jobId": 18,
-                                        "name": "first at LightGBMBase.scala:470",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:56:36.839GMT",
-                                        "completionTime": "2023-05-08T06:56:37.029GMT",
-                                        "stageIds": [29],
-                                        "jobGroup": "8",
-                                        "status": "SUCCEEDED",
                                         "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 13296,
-                                        "rowCount": 13,
-                                        "jobId": 17,
-                                        "name": "collect at StringIndexer.scala:204",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:56:36.092GMT",
-                                        "completionTime": "2023-05-08T06:56:36.151GMT",
-                                        "stageIds": [27, 28],
-                                        "jobGroup": "8",
+                                        "rowCount": 32,
+                                        "stageIds": [
+                                            10
+                                        ],
                                         "status": "SUCCEEDED",
-                                        "numTasks": 14,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 13296,
-                                        "dataRead": 2140848048,
-                                        "rowCount": 1747,
-                                        "jobId": 16,
-                                        "name": "collect at StringIndexer.scala:204",
-                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:56:29.670GMT",
-                                        "completionTime": "2023-05-08T06:56:36.081GMT",
-                                        "stageIds": [26],
-                                        "jobGroup": "8",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 13,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "submissionTime": "2023-05-08T06:55:15.869GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 3,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "e37ecd6a-d322-4538-a8bc-4faaf0ab0670"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 4
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 8, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 4, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
-                    "name": "stdout",
-                    "text": ["Active experiment run_id: 47e80a47-a78f-45bb-925d-a8450e56ace3\nPrediction run for 5754996 samples\n"]
+                    "metadata": {},
+                    "output_type": "display_data"
                 }
             ],
-            "execution_count": 6,
-            "metadata": {}
-        }, {
+            "source": [
+                "SEED = 1234\n",
+                "# note: From the perspective of the tutorial, we are sampling training data to speed up the execution.\n",
+                "training_df = spark.read.format(\"delta\").load(\"Tables/nyctaxi_prep\").sample(fraction = 0.5, seed = SEED)"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Compute Model Statistics for evaluating performance of the trained LightGBMRegressor model"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Perform random split to get train and test datasets and define categorical and numeric features"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["from synapse.ml.train import ComputeModelStatistics\r\n", "lg_metrics = ComputeModelStatistics(\r\n", "    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\r\n", ").transform(lg_predictions) \r\n", "display(lg_metrics)"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 3,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 23,
-                            "state": "finished",
+                            "execution_finish_time": "2023-05-08T06:56:24.1891658Z",
+                            "execution_start_time": "2023-05-08T06:55:21.4205521Z",
                             "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T07:09:49.5327719Z",
+                            "parent_msg_id": "77df141c-597f-4288-a320-a29dd0492f77",
+                            "queued_time": "2023-05-08T06:54:40.368888Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
                             "session_start_time": null,
-                            "execution_start_time": "2023-05-08T07:09:50.4354862Z",
-                            "execution_finish_time": "2023-05-08T07:09:51.4910707Z",
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 1,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 4576,
-                                        "dataRead": 92359840,
-                                        "rowCount": 608,
-                                        "jobId": 51,
-                                        "name": "treeAggregate at Statistics.scala:58",
-                                        "description": "Job group for statement 23:\nfrom synapse.ml.train import ComputeModelStatistics\nlg_metrics = ComputeModelStatistics(\n    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n).transform(lg_predictions) \ndisplay(lg_metrics)",
-                                        "submissionTime": "2023-05-08T07:09:50.320GMT",
-                                        "completionTime": "2023-05-08T07:09:51.181GMT",
-                                        "stageIds": [72, 73],
-                                        "jobGroup": "23",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 16,
+                                "jobs": [
+                                    {
+                                        "completionTime": "2023-05-08T06:56:23.103GMT",
+                                        "dataRead": 767,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
+                                        "jobGroup": "5",
+                                        "jobId": 15,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 16,
-                                        "numSkippedTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 16,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            24,
+                                            25
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:56:23.086GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:56:23.069GMT",
+                                        "dataRead": 1282332012,
+                                        "dataWritten": 767,
+                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
+                                        "jobGroup": "5",
+                                        "jobId": 14,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
                                         "numActiveStages": 0,
-                                        "numCompletedStages": 2,
-                                        "numSkippedStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 13,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 46031000,
+                                        "stageIds": [
+                                            23
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:58.846GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:58.700GMT",
+                                        "dataRead": 767,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
+                                        "jobGroup": "5",
+                                        "jobId": 13,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            21,
+                                            22
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:58.662GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:58.642GMT",
+                                        "dataRead": 1282426207,
+                                        "dataWritten": 767,
+                                        "description": "Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]",
+                                        "jobGroup": "5",
+                                        "jobId": 12,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 13,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 46031000,
+                                        "stageIds": [
+                                            20
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:22.354GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:22.150GMT",
+                                        "dataRead": 16086,
+                                        "dataWritten": 0,
+                                        "description": "Delta: Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]: Filtering files for query",
+                                        "jobGroup": "5",
+                                        "jobId": 11,
+                                        "killedTasksSummary": {},
+                                        "name": "$anonfun$recordDeltaOperationInternal$1 at SynapseLoggingShim.scala:95",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 50,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 50,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 51,
+                                        "rowCount": 15,
+                                        "stageIds": [
+                                            19,
+                                            18
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:21.992GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:55:21.725GMT",
+                                        "dataRead": 16086,
+                                        "dataWritten": 0,
+                                        "description": "Delta: Job group for statement 5:\nTRAIN_TEST_SPLIT = [0.75, 0.25]\ntrain_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n\n# Cache the dataframes to improve the speed of repeatable reads\ntrain_df.cache()\ntest_df.cache()\n\nprint(f\"train set count:{train_df.count()}\")\nprint(f\"test set count:{test_df.count()}\")\n\ncategorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\nnumeric_features = ['passengerCount', \"tripDistance\"]: Filtering files for query",
+                                        "jobGroup": "5",
+                                        "jobId": 10,
+                                        "killedTasksSummary": {},
+                                        "name": "$anonfun$recordDeltaOperationInternal$1 at SynapseLoggingShim.scala:95",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 50,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 50,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 51,
+                                        "rowCount": 15,
+                                        "stageIds": [
+                                            16,
+                                            17
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:55:21.497GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 6,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "42698b45-10b3-4db2-8067-71a8305f4cf4"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 5
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 23, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 5, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "display_data",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "train set count:17256796\n",
+                        "test set count:5754996\n"
+                    ]
+                }
+            ],
+            "source": [
+                "TRAIN_TEST_SPLIT = [0.75, 0.25]\n",
+                "train_df, test_df = training_df.randomSplit(TRAIN_TEST_SPLIT, seed=SEED)\n",
+                "\n",
+                "# Cache the dataframes to improve the speed of repeatable reads\n",
+                "train_df.cache()\n",
+                "test_df.cache()\n",
+                "\n",
+                "print(f\"train set count:{train_df.count()}\")\n",
+                "print(f\"test set count:{test_df.count()}\")\n",
+                "\n",
+                "categorical_features = [\"storeAndFwdFlag\",\"timeBins\",\"vendorID\",\"weekDayName\",\"pickupHour\",\"rateCodeId\",\"paymentType\"]\n",
+                "numeric_features = ['passengerCount', \"tripDistance\"]"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Define the steps to perform additional feature engineering and train the model using Spark ML pipelines and Microsoft SynapseML library\n",
+                "You can learn more about Spark ML pipelines [here](https://spark.apache.org/docs/latest/ml-pipeline.html), and SynapseML is documented [here](https://microsoft.github.io/SynapseML/docs/about/)\n",
+                "\n",
+                "The algorithm used for this tutorial, [LightGBM](https://lightgbm.readthedocs.io/en/v3.3.2/) is a fast, distributed, high performance gradient boosting framework based on decision tree algorithms. It is an open source project developed by Microsoft and supports regression, classification and many other machine learning scenarios. Its main advantages are faster training speed, lower memory usage, better accuracy, and support for distributed learning."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "application/vnd.livy.statement-meta+json": {
+                            "execution_finish_time": "2023-05-08T06:56:25.6028613Z",
+                            "execution_start_time": "2023-05-08T06:56:25.2625578Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "77d42f20-a644-4a19-8eda-aad67facb410",
+                            "queued_time": "2023-05-08T06:54:40.3758597Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
+                            "spark_jobs": {
+                                "jobs": [],
+                                "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 0,
+                                    "UNKNOWN": 0
+                                },
+                                "rule": "ALL_DESC"
+                            },
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 6
+                        },
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 6, Finished, Available)"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "from pyspark.ml.feature import OneHotEncoder, VectorAssembler, StringIndexer\n",
+                "from pyspark.ml import Pipeline\n",
+                "from synapse.ml.core.platform import *\n",
+                "from synapse.ml.lightgbm import LightGBMRegressor\n",
+                "\n",
+                "# Define a pipeline steps for training a LightGBMRegressor regressor model\n",
+                "def lgbm_pipeline(categorical_features,numeric_features, hyperparameters):\n",
+                "    # String indexer\n",
+                "    stri = StringIndexer(inputCols=categorical_features, \n",
+                "                        outputCols=[f\"{feat}Idx\" for feat in categorical_features]).setHandleInvalid(\"keep\")\n",
+                "    # encode categorical/indexed columns\n",
+                "    ohe = OneHotEncoder(inputCols= stri.getOutputCols(),  \n",
+                "                        outputCols=[f\"{feat}Enc\" for feat in categorical_features])\n",
+                "    \n",
+                "    # convert all feature columns into a vector\n",
+                "    featurizer = VectorAssembler(inputCols=ohe.getOutputCols() + numeric_features, outputCol=\"features\")\n",
+                "\n",
+                "    # Define the LightGBM regressor\n",
+                "    lgr = LightGBMRegressor(\n",
+                "        objective = hyperparameters[\"objective\"],\n",
+                "        alpha = hyperparameters[\"alpha\"],\n",
+                "        learningRate = hyperparameters[\"learning_rate\"],\n",
+                "        numLeaves = hyperparameters[\"num_leaves\"],\n",
+                "        labelCol=\"tripDuration\",\n",
+                "        numIterations = hyperparameters[\"iterations\"],\n",
+                "    )\n",
+                "    # Define the steps and sequence of the SPark ML pipeline\n",
+                "    ml_pipeline = Pipeline(stages=[stri, ohe, featurizer, lgr])\n",
+                "    return ml_pipeline\n"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Define Training Hyperparameters\n",
+                "Hyperparameters are the parameters that you can change to control how a machine learning model is trained. Hyperparameters can affect the speed, quality and accuracy of the model. Some common methods to find the best hyperparameters are by testing different values, using a grid or random search, or using a more advanced optimization technique.\n",
+                "The hyperparameters for the lightgbm model in this tutorial have been pre-tuned using a distributed gridsearch run using [hyperopt](https://github.com/hyperopt/hyperopt)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Model Run 1: Using default lightgbm hyperparameters"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "application/vnd.livy.statement-meta+json": {
+                            "execution_finish_time": "2023-05-08T06:56:27.103696Z",
+                            "execution_start_time": "2023-05-08T06:56:26.7476777Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "b311354f-d27a-414f-bb32-8b775647d2a7",
+                            "queued_time": "2023-05-08T06:54:40.3769966Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
+                            "spark_jobs": {
+                                "jobs": [],
+                                "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 0,
+                                    "UNKNOWN": 0
+                                },
+                                "rule": "ALL_DESC"
+                            },
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 7
+                        },
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 7, Finished, Available)"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "# Default hyperparameters for LightGBM Model\n",
+                "LGBM_PARAMS = {\"objective\":\"regression\",\n",
+                "    \"alpha\":0.9,\n",
+                "    \"learning_rate\":0.1,\n",
+                "    \"num_leaves\":31,\n",
+                "    \"iterations\":100}"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Fit the defined pipeline on the training dataframe and generate predictions on the test dataset"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "application/vnd.livy.statement-meta+json": {
+                            "execution_finish_time": "2023-05-08T06:58:52.2672455Z",
+                            "execution_start_time": "2023-05-08T06:56:28.2995355Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "e37ecd6a-d322-4538-a8bc-4faaf0ab0670",
+                            "queued_time": "2023-05-08T06:54:40.3849016Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
+                            "spark_jobs": {
+                                "jobs": [
+                                    {
+                                        "completionTime": "2023-05-08T06:58:49.972GMT",
+                                        "dataRead": 767,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 21,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            33,
+                                            32
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:58:49.952GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:58:49.934GMT",
+                                        "dataRead": 714202176,
+                                        "dataWritten": 767,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 20,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 13,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 595,
+                                        "stageIds": [
+                                            31
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:57:31.849GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:57:31.443GMT",
+                                        "dataRead": 2140848048,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 19,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at LightGBMBase.scala:597",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 8,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 8,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 8,
+                                        "rowCount": 1734,
+                                        "stageIds": [
+                                            30
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:56:37.189GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:56:37.029GMT",
+                                        "dataRead": 207605448,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 18,
+                                        "killedTasksSummary": {},
+                                        "name": "first at LightGBMBase.scala:470",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            29
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:56:36.839GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:56:36.151GMT",
+                                        "dataRead": 13296,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 17,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at StringIndexer.scala:204",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            27,
+                                            28
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:56:36.092GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:56:36.081GMT",
+                                        "dataRead": 2140848048,
+                                        "dataWritten": 13296,
+                                        "description": "Job group for statement 8:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\nlg_model = lg_pipeline.fit(train_df)\n\n# Get Predictions\nlg_predictions = lg_model.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions.cache()\nprint(f\"Prediction run for {lg_predictions.count()} samples\")",
+                                        "jobGroup": "8",
+                                        "jobId": 16,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at StringIndexer.scala:204",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 13,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 1747,
+                                        "stageIds": [
+                                            26
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:56:29.670GMT"
+                                    }
+                                ],
+                                "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 6,
+                                    "UNKNOWN": 0
+                                },
+                                "rule": "ALL_DESC"
+                            },
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 8
+                        },
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 8, Finished, Available)"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Active experiment run_id: 47e80a47-a78f-45bb-925d-a8450e56ace3\n",
+                        "Prediction run for 5754996 samples\n"
+                    ]
+                }
+            ],
+            "source": [
+                "if mlflow.active_run() is None:\n",
+                "    mlflow.start_run()\n",
+                "run = mlflow.active_run()\n",
+                "print(f\"Active experiment run_id: {run.info.run_id}\")\n",
+                "lg_pipeline = lgbm_pipeline(categorical_features,numeric_features,LGBM_PARAMS)\n",
+                "lg_model = lg_pipeline.fit(train_df)\n",
+                "\n",
+                "# Get Predictions\n",
+                "lg_predictions = lg_model.transform(test_df)\n",
+                "## Caching predictions to run model evaluation faster\n",
+                "lg_predictions.cache()\n",
+                "print(f\"Prediction run for {lg_predictions.count()} samples\")"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Compute Model Statistics for evaluating performance of the trained LightGBMRegressor model"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 21,
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "application/vnd.livy.statement-meta+json": {
+                            "execution_finish_time": "2023-05-08T07:09:51.4910707Z",
+                            "execution_start_time": "2023-05-08T07:09:50.4354862Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "42698b45-10b3-4db2-8067-71a8305f4cf4",
+                            "queued_time": "2023-05-08T07:09:49.5327719Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
+                            "spark_jobs": {
+                                "jobs": [
+                                    {
+                                        "completionTime": "2023-05-08T07:09:51.181GMT",
+                                        "dataRead": 92359840,
+                                        "dataWritten": 4576,
+                                        "description": "Job group for statement 23:\nfrom synapse.ml.train import ComputeModelStatistics\nlg_metrics = ComputeModelStatistics(\n    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n).transform(lg_predictions) \ndisplay(lg_metrics)",
+                                        "jobGroup": "23",
+                                        "jobId": 51,
+                                        "killedTasksSummary": {},
+                                        "name": "treeAggregate at Statistics.scala:58",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 16,
+                                        "numCompletedStages": 2,
+                                        "numCompletedTasks": 16,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 16,
+                                        "rowCount": 608,
+                                        "stageIds": [
+                                            72,
+                                            73
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:09:50.320GMT"
+                                    }
+                                ],
+                                "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 1,
+                                    "UNKNOWN": 0
+                                },
+                                "rule": "ALL_DESC"
+                            },
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 23
+                        },
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 23, Finished, Available)"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "data": {
                         "application/vnd.synapse.widget-view+json": {
                             "widget_id": "838a4109-46a5-43e7-92c9-e60eb76d273f",
                             "widget_type": "Synapse.DataFrame"
                         },
-                        "text/plain": "SynapseWidget(Synapse.DataFrame, 838a4109-46a5-43e7-92c9-e60eb76d273f)"
+                        "text/plain": [
+                            "SynapseWidget(Synapse.DataFrame, 838a4109-46a5-43e7-92c9-e60eb76d273f)"
+                        ]
                     },
-                    "metadata": {}
+                    "metadata": {},
+                    "output_type": "display_data"
                 }
             ],
-            "execution_count": 21,
-            "metadata": {
-                "collapsed": false
-            }
-        }, {
+            "source": [
+                "from synapse.ml.train import ComputeModelStatistics\n",
+                "lg_metrics = ComputeModelStatistics(\n",
+                "    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n",
+                ").transform(lg_predictions) \n",
+                "display(lg_metrics)"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Register the trained LightGBMRegressor model using MLflow"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Register the trained LightGBMRegressor model using MLflow"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["from mlflow.models.signature import ModelSignature \r\n", "from mlflow.types.utils import _infer_schema \r\n", "\r\n", "# Define a function to register a spark model\r\n", "def register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\r\n", "        # log the model, parameters and metrics\r\n", "        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \r\n", "        mlflow.log_params(hyperparameters) \r\n", "        mlflow.log_metrics(metrics) \r\n", "        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \r\n", "        print(f\"Model saved in run{run.info.run_id}\") \r\n", "        print(f\"Model URI: {model_uri}\")\r\n", "        return model_uri\r\n", "\r\n", "# Define Signature object \r\n", "sig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \r\n", "                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \r\n", "\r\n", "ALGORITHM = \"lightgbm\" \r\n", "model_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\r\n", "\r\n", "# Create a 'dict' object that contains values of metrics\r\n", "lg_metrics_dict = json.loads(lg_metrics.toJSON().first())\r\n", "\r\n", "# Call model register function\r\n", "model_uri = register_spark_model(run = run,\r\n", "                                model = lg_model, \r\n", "                                model_name = model_name, \r\n", "                                signature = sig, \r\n", "                                metrics = lg_metrics_dict, \r\n", "                                hyperparameters = LGBM_PARAMS)\r\n", "mlflow.end_run()"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 8,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 10,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3872029Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:58:57.198914Z",
                             "execution_finish_time": "2023-05-08T06:59:37.6686934Z",
+                            "execution_start_time": "2023-05-08T06:58:57.198914Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "f44e1c6a-4ba9-4ac5-b39a-a6bc7cc349dd",
+                            "queued_time": "2023-05-08T06:54:40.3872029Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 9,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 665,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 32,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:07.571GMT",
+                                "jobs": [
+                                    {
                                         "completionTime": "2023-05-08T06:59:08.233GMT",
-                                        "stageIds": [47],
+                                        "dataRead": 0,
+                                        "dataWritten": 665,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
                                         "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 32,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 447,
-                                        "dataRead": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 31,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:06.114GMT",
+                                        "stageIds": [
+                                            47
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:07.571GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T06:59:06.794GMT",
-                                        "stageIds": [46],
+                                        "dataRead": 0,
+                                        "dataWritten": 447,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
                                         "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 31,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 814,
-                                        "dataRead": 90,
-                                        "rowCount": 2,
-                                        "jobId": 30,
-                                        "name": "parquet at OneHotEncoder.scala:407",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:04.666GMT",
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            46
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:06.114GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T06:59:05.380GMT",
-                                        "stageIds": [45, 44],
+                                        "dataRead": 90,
+                                        "dataWritten": 814,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
                                         "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 2,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 90,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 29,
+                                        "jobId": 30,
+                                        "killedTasksSummary": {},
                                         "name": "parquet at OneHotEncoder.scala:407",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:04.622GMT",
-                                        "completionTime": "2023-05-08T06:59:04.638GMT",
-                                        "stageIds": [43],
-                                        "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
                                         "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
+                                        "numCompletedTasks": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 537,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 28,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:03.038GMT",
-                                        "completionTime": "2023-05-08T06:59:03.873GMT",
-                                        "stageIds": [42],
-                                        "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 1169,
-                                        "dataRead": 644,
-                                        "rowCount": 2,
-                                        "jobId": 27,
-                                        "name": "parquet at StringIndexer.scala:499",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:01.389GMT",
-                                        "completionTime": "2023-05-08T06:59:02.205GMT",
-                                        "stageIds": [40, 41],
-                                        "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 2,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 644,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 2,
+                                        "rowCount": 2,
+                                        "stageIds": [
+                                            45,
+                                            44
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:04.666GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:04.638GMT",
                                         "dataRead": 0,
+                                        "dataWritten": 90,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
+                                        "jobGroup": "10",
+                                        "jobId": 29,
+                                        "killedTasksSummary": {},
+                                        "name": "parquet at OneHotEncoder.scala:407",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 26,
+                                        "stageIds": [
+                                            43
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:04.622GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:03.873GMT",
+                                        "dataRead": 0,
+                                        "dataWritten": 537,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
+                                        "jobGroup": "10",
+                                        "jobId": 28,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            42
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:03.038GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:02.205GMT",
+                                        "dataRead": 644,
+                                        "dataWritten": 1169,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
+                                        "jobGroup": "10",
+                                        "jobId": 27,
+                                        "killedTasksSummary": {},
                                         "name": "parquet at StringIndexer.scala:499",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:01.346GMT",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 2,
+                                        "rowCount": 2,
+                                        "stageIds": [
+                                            40,
+                                            41
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:01.389GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T06:59:01.362GMT",
-                                        "stageIds": [39],
+                                        "dataRead": 0,
+                                        "dataWritten": 644,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
                                         "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 26,
+                                        "killedTasksSummary": {},
+                                        "name": "parquet at StringIndexer.scala:499",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 557,
-                                        "dataRead": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 25,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:59:00.035GMT",
+                                        "stageIds": [
+                                            39
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:01.346GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T06:59:00.672GMT",
-                                        "stageIds": [38],
-                                        "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 313,
                                         "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 24,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "dataWritten": 557,
                                         "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
-                                        "submissionTime": "2023-05-08T06:58:58.411GMT",
-                                        "completionTime": "2023-05-08T06:58:59.257GMT",
-                                        "stageIds": [37],
                                         "jobGroup": "10",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 25,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            38
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:00.035GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:58:59.257GMT",
+                                        "dataRead": 0,
+                                        "dataWritten": 313,
+                                        "description": "Job group for statement 10:\nfrom mlflow.models.signature import ModelSignature \nfrom mlflow.types.utils import _infer_schema \n\n# Define a function to register a spark model\ndef register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n        # log the model, parameters and metrics\n        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n        mlflow.log_params(hyperparameters) \n        mlflow.log_metrics(metrics) \n        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n        print(f\"Model saved in run{run.info.run_id}\") \n        print(f\"Model URI: {model_uri}\")\n        return model_uri\n\n# Define Signature object \nsig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n\nALGORITHM = \"lightgbm\" \nmodel_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n\n# Call model register function\nmodel_uri = regis...",
+                                        "jobGroup": "10",
+                                        "jobId": 24,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            37
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:58:58.411GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 9,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "f44e1c6a-4ba9-4ac5-b39a-a6bc7cc349dd"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 10
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 10, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 10, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "name": "stderr",
-                    "text": ["/tmp/ipykernel_7705/2352378258.py:16: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.\n  sig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)),\n2023/05/08 06:59:19 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /tmp/tmp_ldwrdfe/model, flavor: spark), fall back to return ['pyspark==3.3.1']. Set logging level to DEBUG to see the full traceback.\n/home/trusted-service-user/cluster-env/trident_env/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.\n  warnings.warn(\"Setuptools is replacing distutils.\")\nSuccessfully registered model 'nyctaxi_tripduration_lightgbm'.\n2023/05/08 06:59:33 INFO mlflow.tracking._model_registry.client: Waiting up to 300 seconds for model version to finish creation.                     Model name: nyctaxi_tripduration_lightgbm, version 1\nCreated version '1' of model 'nyctaxi_tripduration_lightgbm'.\n"]
-                }, {
                     "output_type": "stream",
+                    "text": [
+                        "/tmp/ipykernel_7705/2352378258.py:16: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.\n",
+                        "  sig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)),\n",
+                        "2023/05/08 06:59:19 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /tmp/tmp_ldwrdfe/model, flavor: spark), fall back to return ['pyspark==3.3.1']. Set logging level to DEBUG to see the full traceback.\n",
+                        "/home/trusted-service-user/cluster-env/trident_env/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.\n",
+                        "  warnings.warn(\"Setuptools is replacing distutils.\")\n",
+                        "Successfully registered model 'nyctaxi_tripduration_lightgbm'.\n",
+                        "2023/05/08 06:59:33 INFO mlflow.tracking._model_registry.client: Waiting up to 300 seconds for model version to finish creation.                     Model name: nyctaxi_tripduration_lightgbm, version 1\n",
+                        "Created version '1' of model 'nyctaxi_tripduration_lightgbm'.\n"
+                    ]
+                },
+                {
                     "name": "stdout",
-                    "text": ["Model saved in run47e80a47-a78f-45bb-925d-a8450e56ace3\nModel URI: runs:/47e80a47-a78f-45bb-925d-a8450e56ace3/nyctaxi_tripduration_lightgbm\n"]
+                    "output_type": "stream",
+                    "text": [
+                        "Model saved in run47e80a47-a78f-45bb-925d-a8450e56ace3\n",
+                        "Model URI: runs:/47e80a47-a78f-45bb-925d-a8450e56ace3/nyctaxi_tripduration_lightgbm\n"
+                    ]
                 }
             ],
-            "execution_count": 8,
-            "metadata": {}
-        }, {
+            "source": [
+                "from mlflow.models.signature import ModelSignature \n",
+                "from mlflow.types.utils import _infer_schema\n",
+                "import json\n",
+                "\n",
+                "# Define a function to register a spark model\n",
+                "def register_spark_model(run, model, model_name,signature,metrics, hyperparameters):\n",
+                "        # log the model, parameters and metrics\n",
+                "        mlflow.spark.log_model(model, artifact_path = model_name, signature=signature, registered_model_name = model_name, dfs_tmpdir=\"Files/tmp/mlflow\") \n",
+                "        mlflow.log_params(hyperparameters) \n",
+                "        mlflow.log_metrics(metrics) \n",
+                "        model_uri = f\"runs:/{run.info.run_id}/{model_name}\" \n",
+                "        print(f\"Model saved in run{run.info.run_id}\") \n",
+                "        print(f\"Model URI: {model_uri}\")\n",
+                "        return model_uri\n",
+                "\n",
+                "# Define Signature object \n",
+                "sig = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n",
+                "                     outputs=_infer_schema(train_df.select(\"tripDuration\"))) \n",
+                "\n",
+                "ALGORITHM = \"lightgbm\" \n",
+                "model_name = f\"{EXPERIMENT_NAME}_{ALGORITHM}\"\n",
+                "\n",
+                "# Create a 'dict' object that contains values of metrics\n",
+                "lg_metrics_dict = json.loads(lg_metrics.toJSON().first())\n",
+                "\n",
+                "# Call model register function\n",
+                "model_uri = register_spark_model(run = run,\n",
+                "                                model = lg_model, \n",
+                "                                model_name = model_name, \n",
+                "                                signature = sig, \n",
+                "                                metrics = lg_metrics_dict, \n",
+                "                                hyperparameters = LGBM_PARAMS)\n",
+                "mlflow.end_run()"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Model Run 2: Using tuned lightgbm hyperparameters and remove paymentType \r\n", "Since paymentType is usually selected at the end of a trip, we hypothize that it shouldn't be useful to predict trip duration."],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Model Run 2: Using tuned lightgbm hyperparameters and remove paymentType \n",
+                "Since paymentType is usually selected at the end of a trip, we hypothize that it shouldn't be useful to predict trip duration."
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["# Tuned hyperparameters for LightGBM Model\r\n", "TUNED_LGBM_PARAMS = {\"objective\":\"regression\",\r\n", "    \"alpha\":0.08373361416254149,\r\n", "    \"learning_rate\":0.0801709918703746,\r\n", "    \"num_leaves\":92,\r\n", "    \"iterations\":200}\r\n", "\r\n", "# Remove paymentType\r\n", "categorical_features.remove(\"paymentType\")"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 9,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 11,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3937554Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:59:38.8940543Z",
                             "execution_finish_time": "2023-05-08T06:59:39.2579897Z",
+                            "execution_start_time": "2023-05-08T06:59:38.8940543Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "2a29e256-31e3-4a8c-9901-15028f674568",
+                            "queued_time": "2023-05-08T06:54:40.3937554Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 0,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
                                 "jobs": [],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 0,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "2a29e256-31e3-4a8c-9901-15028f674568"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 11
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 11, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 11, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
+                    "metadata": {},
+                    "output_type": "display_data"
                 }
             ],
-            "execution_count": 9,
-            "metadata": {}
-        }, {
+            "source": [
+                "# Tuned hyperparameters for LightGBM Model\n",
+                "TUNED_LGBM_PARAMS = {\"objective\":\"regression\",\n",
+                "    \"alpha\":0.08373361416254149,\n",
+                "    \"learning_rate\":0.0801709918703746,\n",
+                "    \"num_leaves\":92,\n",
+                "    \"iterations\":200}\n",
+                "\n",
+                "# Remove paymentType\n",
+                "categorical_features.remove(\"paymentType\")"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Fit the lightgbm pipeline with tuned hyperparameter on the training dataframe and generate predictions on the test dataset"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Fit the lightgbm pipeline with tuned hyperparameter on the training dataframe and generate predictions on the test dataset"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["if mlflow.active_run() is None:\r\n", "    mlflow.start_run()\r\n", "run = mlflow.active_run()\r\n", "print(f\"Active experiment run_id: {run.info.run_id}\")\r\n", "lg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\r\n", "lg_model_tn = lg_pipeline_tn.fit(train_df)\r\n", "\r\n", "# Get Predictions\r\n", "lg_predictions_tn = lg_model_tn.transform(test_df)\r\n", "## Caching predictions to run model evaluation faster\r\n", "lg_predictions_tn.cache()\r\n", "print(f\"Prediction run for {lg_predictions_tn.count()} samples\")"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 10,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 12,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3949102Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T06:59:40.3005994Z",
                             "execution_finish_time": "2023-05-08T07:03:16.6522547Z",
+                            "execution_start_time": "2023-05-08T06:59:40.3005994Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "dc92aef8-3df2-48eb-aa26-f636a5f77295",
+                            "queued_time": "2023-05-08T06:54:40.3949102Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 6,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 0,
-                                        "dataRead": 767,
-                                        "rowCount": 13,
-                                        "jobId": 38,
-                                        "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T07:03:14.230GMT",
+                                "jobs": [
+                                    {
                                         "completionTime": "2023-05-08T07:03:14.518GMT",
-                                        "stageIds": [54, 55],
+                                        "dataRead": 767,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
                                         "jobGroup": "12",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 14,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 767,
-                                        "dataRead": 1282426207,
-                                        "rowCount": 46031000,
-                                        "jobId": 37,
+                                        "jobId": 38,
+                                        "killedTasksSummary": {},
                                         "name": "count at NativeMethodAccessorImpl.java:0",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T07:01:10.493GMT",
-                                        "completionTime": "2023-05-08T07:03:14.212GMT",
-                                        "stageIds": [53],
-                                        "jobGroup": "12",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 13,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
                                         "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 2140848048,
-                                        "rowCount": 1734,
-                                        "jobId": 36,
-                                        "name": "collect at LightGBMBase.scala:597",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:59:46.633GMT",
-                                        "completionTime": "2023-05-08T07:01:09.226GMT",
-                                        "stageIds": [52],
-                                        "jobGroup": "12",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 8,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 8,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 8,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 207605448,
-                                        "rowCount": 1,
-                                        "jobId": 35,
-                                        "name": "first at LightGBMBase.scala:470",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:59:46.545GMT",
-                                        "completionTime": "2023-05-08T06:59:46.587GMT",
-                                        "stageIds": [51],
-                                        "jobGroup": "12",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
                                         "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 0,
-                                        "dataRead": 12513,
-                                        "rowCount": 13,
-                                        "jobId": 34,
-                                        "name": "collect at StringIndexer.scala:204",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:59:46.049GMT",
-                                        "completionTime": "2023-05-08T06:59:46.087GMT",
-                                        "stageIds": [49, 50],
-                                        "jobGroup": "12",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 14,
-                                        "numActiveTasks": 0,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 13,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 12513,
-                                        "dataRead": 2140848048,
-                                        "rowCount": 1747,
-                                        "jobId": 33,
-                                        "name": "collect at StringIndexer.scala:204",
-                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
-                                        "submissionTime": "2023-05-08T06:59:40.636GMT",
-                                        "completionTime": "2023-05-08T06:59:46.034GMT",
-                                        "stageIds": [48],
-                                        "jobGroup": "12",
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            54,
+                                            55
+                                        ],
                                         "status": "SUCCEEDED",
-                                        "numTasks": 13,
+                                        "submissionTime": "2023-05-08T07:03:14.230GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:14.212GMT",
+                                        "dataRead": 1282426207,
+                                        "dataWritten": 767,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
+                                        "jobGroup": "12",
+                                        "jobId": 37,
+                                        "killedTasksSummary": {},
+                                        "name": "count at NativeMethodAccessorImpl.java:0",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 13,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 13,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 46031000,
+                                        "stageIds": [
+                                            53
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:01:10.493GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:01:09.226GMT",
+                                        "dataRead": 2140848048,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
+                                        "jobGroup": "12",
+                                        "jobId": 36,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at LightGBMBase.scala:597",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 8,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 8,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 8,
+                                        "rowCount": 1734,
+                                        "stageIds": [
+                                            52
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:46.633GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:46.587GMT",
+                                        "dataRead": 207605448,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
+                                        "jobGroup": "12",
+                                        "jobId": 35,
+                                        "killedTasksSummary": {},
+                                        "name": "first at LightGBMBase.scala:470",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            51
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:46.545GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:46.087GMT",
+                                        "dataRead": 12513,
+                                        "dataWritten": 0,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
+                                        "jobGroup": "12",
+                                        "jobId": 34,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at StringIndexer.scala:204",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 13,
+                                        "numTasks": 14,
+                                        "rowCount": 13,
+                                        "stageIds": [
+                                            49,
+                                            50
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:46.049GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T06:59:46.034GMT",
+                                        "dataRead": 2140848048,
+                                        "dataWritten": 12513,
+                                        "description": "Job group for statement 12:\nif mlflow.active_run() is None:\n    mlflow.start_run()\nrun = mlflow.active_run()\nprint(f\"Active experiment run_id: {run.info.run_id}\")\nlg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\nlg_model_tn = lg_pipeline_tn.fit(train_df)\n\n# Get Predictions\nlg_predictions_tn = lg_model_tn.transform(test_df)\n## Caching predictions to run model evaluation faster\nlg_predictions_tn.cache()\nprint(f\"Prediction run for {lg_predictions_tn.count()} samples\")",
+                                        "jobGroup": "12",
+                                        "jobId": 33,
+                                        "killedTasksSummary": {},
+                                        "name": "collect at StringIndexer.scala:204",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 13,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 13,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 13,
+                                        "rowCount": 1747,
+                                        "stageIds": [
+                                            48
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T06:59:40.636GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 6,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "dc92aef8-3df2-48eb-aa26-f636a5f77295"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 12
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 12, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 12, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "name": "stdout",
-                    "text": ["Active experiment run_id: b1bb91e0-55cf-4302-86d5-53b8aba63d13\nPrediction run for 5754996 samples\n"]
+                    "output_type": "stream",
+                    "text": [
+                        "Active experiment run_id: b1bb91e0-55cf-4302-86d5-53b8aba63d13\n",
+                        "Prediction run for 5754996 samples\n"
+                    ]
                 }
             ],
-            "execution_count": 10,
-            "metadata": {}
-        }, {
+            "source": [
+                "if mlflow.active_run() is None:\n",
+                "    mlflow.start_run()\n",
+                "run = mlflow.active_run()\n",
+                "print(f\"Active experiment run_id: {run.info.run_id}\")\n",
+                "lg_pipeline_tn = lgbm_pipeline(categorical_features,numeric_features,TUNED_LGBM_PARAMS)\n",
+                "lg_model_tn = lg_pipeline_tn.fit(train_df)\n",
+                "\n",
+                "# Get Predictions\n",
+                "lg_predictions_tn = lg_model_tn.transform(test_df)\n",
+                "## Caching predictions to run model evaluation faster\n",
+                "lg_predictions_tn.cache()\n",
+                "print(f\"Prediction run for {lg_predictions_tn.count()} samples\")"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["lg_metrics_tn = ComputeModelStatistics(\r\n", "    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\r\n", ").transform(lg_predictions_tn)\r\n", "display(lg_metrics_tn)"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 11,
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 13,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3961667Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T07:03:18.12572Z",
                             "execution_finish_time": "2023-05-08T07:03:23.4640486Z",
+                            "execution_start_time": "2023-05-08T07:03:18.12572Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "207dd647-2772-4b14-8ebd-93f875523aba",
+                            "queued_time": "2023-05-08T06:54:40.3961667Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 2,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 0,
-                                        "dataRead": 0,
-                                        "rowCount": 0,
-                                        "jobId": 40,
-                                        "name": "runJob at PythonRDD.scala:172",
-                                        "description": "Job group for statement 13:\nlg_metrics_tn = ComputeModelStatistics(\n    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n).transform(lg_predictions_tn)\nlg_metricstn_dict = json.loads(lg_metrics_tn.toJSON().first())\ndisplay(lg_metrics_tn)",
-                                        "submissionTime": "2023-05-08T07:03:19.822GMT",
+                                "jobs": [
+                                    {
                                         "completionTime": "2023-05-08T07:03:23.063GMT",
-                                        "stageIds": [58],
-                                        "jobGroup": "13",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 4576,
-                                        "dataRead": 5210406048,
-                                        "rowCount": 1372,
-                                        "jobId": 39,
-                                        "name": "treeAggregate at Statistics.scala:58",
+                                        "dataRead": 0,
+                                        "dataWritten": 0,
                                         "description": "Job group for statement 13:\nlg_metrics_tn = ComputeModelStatistics(\n    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n).transform(lg_predictions_tn)\nlg_metricstn_dict = json.loads(lg_metrics_tn.toJSON().first())\ndisplay(lg_metrics_tn)",
-                                        "submissionTime": "2023-05-08T07:03:17.908GMT",
-                                        "completionTime": "2023-05-08T07:03:19.775GMT",
-                                        "stageIds": [56, 57],
                                         "jobGroup": "13",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 16,
+                                        "jobId": 40,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at PythonRDD.scala:172",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
-                                        "numCompletedTasks": 16,
-                                        "numSkippedTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 16,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 2,
                                         "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 0,
+                                        "stageIds": [
+                                            58
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:19.822GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:19.775GMT",
+                                        "dataRead": 5210406048,
+                                        "dataWritten": 4576,
+                                        "description": "Job group for statement 13:\nlg_metrics_tn = ComputeModelStatistics(\n    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n).transform(lg_predictions_tn)\nlg_metricstn_dict = json.loads(lg_metrics_tn.toJSON().first())\ndisplay(lg_metrics_tn)",
+                                        "jobGroup": "13",
+                                        "jobId": 39,
+                                        "killedTasksSummary": {},
+                                        "name": "treeAggregate at Statistics.scala:58",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 16,
+                                        "numCompletedStages": 2,
+                                        "numCompletedTasks": 16,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 16,
+                                        "rowCount": 1372,
+                                        "stageIds": [
+                                            56,
+                                            57
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:17.908GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 2,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "207dd647-2772-4b14-8ebd-93f875523aba"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 13
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 13, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 13, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "display_data",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "data": {
                         "application/vnd.synapse.widget-view+json": {
                             "widget_id": "11961b27-2c93-4331-9f4c-a53e994a9907",
                             "widget_type": "Synapse.DataFrame"
                         },
-                        "text/plain": "SynapseWidget(Synapse.DataFrame, 11961b27-2c93-4331-9f4c-a53e994a9907)"
+                        "text/plain": [
+                            "SynapseWidget(Synapse.DataFrame, 11961b27-2c93-4331-9f4c-a53e994a9907)"
+                        ]
                     },
-                    "metadata": {}
+                    "metadata": {},
+                    "output_type": "display_data"
                 }
             ],
-            "execution_count": 11,
-            "metadata": {
-                "collapsed": false
-            }
-        }, {
+            "source": [
+                "lg_metrics_tn = ComputeModelStatistics(\n",
+                "    evaluationMetric=\"regression\", labelCol=\"tripDuration\", scoresCol=\"prediction\"\n",
+                ").transform(lg_predictions_tn)\n",
+                "display(lg_metrics_tn)"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### Register the trained LightGBMRegressor model using MLflow"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### Register the trained LightGBMRegressor model using MLflow"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["# Define Signature object \r\n", "sig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \r\n", "                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\r\n", "\r\n", "# Create a 'dict' object that contains values of metrics\r\n", "lg_metricstn_dict = json.loads(lg_metrics_tn.toJSON().first())\r\n", "\r\n", "model_uri = register_spark_model(run = run,\r\n", "                                model = lg_model_tn, \r\n", "                                model_name = model_name, \r\n", "                                signature = sig_tn, \r\n", "                                metrics = lg_metricstn_dict, \r\n", "                                hyperparameters = TUNED_LGBM_PARAMS)\r\n", "mlflow.end_run()"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 12,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 14,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3974592Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T07:03:24.5869123Z",
                             "execution_finish_time": "2023-05-08T07:04:02.5791945Z",
+                            "execution_start_time": "2023-05-08T07:03:24.5869123Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "b5b0b88e-08bb-4b98-8241-3708f0dd1322",
+                            "queued_time": "2023-05-08T06:54:40.3974592Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 9,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
-                                "jobs": [{
-                                        "dataWritten": 665,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 49,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:36.273GMT",
+                                "jobs": [
+                                    {
                                         "completionTime": "2023-05-08T07:03:36.896GMT",
-                                        "stageIds": [69],
+                                        "dataRead": 0,
+                                        "dataWritten": 665,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
                                         "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 49,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 430,
-                                        "dataRead": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 48,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:34.957GMT",
+                                        "stageIds": [
+                                            69
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:36.273GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T07:03:35.611GMT",
-                                        "stageIds": [68],
+                                        "dataRead": 0,
+                                        "dataWritten": 430,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
                                         "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 48,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 814,
-                                        "dataRead": 86,
-                                        "rowCount": 2,
-                                        "jobId": 47,
-                                        "name": "parquet at OneHotEncoder.scala:407",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:33.456GMT",
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            68
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:34.957GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T07:03:34.388GMT",
-                                        "stageIds": [66, 67],
+                                        "dataRead": 86,
+                                        "dataWritten": 814,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
                                         "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 2,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 86,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 46,
+                                        "jobId": 47,
+                                        "killedTasksSummary": {},
                                         "name": "parquet at OneHotEncoder.scala:407",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:33.419GMT",
-                                        "completionTime": "2023-05-08T07:03:33.432GMT",
-                                        "stageIds": [65],
-                                        "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
                                         "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
                                         "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
+                                        "numCompletedTasks": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 503,
-                                        "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 45,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:31.846GMT",
-                                        "completionTime": "2023-05-08T07:03:32.656GMT",
-                                        "stageIds": [64],
-                                        "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 1158,
-                                        "dataRead": 603,
-                                        "rowCount": 2,
-                                        "jobId": 44,
-                                        "name": "parquet at StringIndexer.scala:499",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:28.908GMT",
-                                        "completionTime": "2023-05-08T07:03:31.179GMT",
-                                        "stageIds": [63, 62],
-                                        "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 2,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 1,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 1,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 603,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 2,
+                                        "rowCount": 2,
+                                        "stageIds": [
+                                            66,
+                                            67
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:33.456GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:33.432GMT",
                                         "dataRead": 0,
+                                        "dataWritten": 86,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
+                                        "jobGroup": "14",
+                                        "jobId": 46,
+                                        "killedTasksSummary": {},
+                                        "name": "parquet at OneHotEncoder.scala:407",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 43,
+                                        "stageIds": [
+                                            65
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:33.419GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:32.656GMT",
+                                        "dataRead": 0,
+                                        "dataWritten": 503,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
+                                        "jobGroup": "14",
+                                        "jobId": 45,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            64
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:31.846GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:31.179GMT",
+                                        "dataRead": 603,
+                                        "dataWritten": 1158,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
+                                        "jobGroup": "14",
+                                        "jobId": 44,
+                                        "killedTasksSummary": {},
                                         "name": "parquet at StringIndexer.scala:499",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:28.869GMT",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
+                                        "numFailedStages": 0,
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 1,
+                                        "numSkippedTasks": 1,
+                                        "numTasks": 2,
+                                        "rowCount": 2,
+                                        "stageIds": [
+                                            63,
+                                            62
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:28.908GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T07:03:28.883GMT",
-                                        "stageIds": [61],
+                                        "dataRead": 0,
+                                        "dataWritten": 603,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
                                         "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 43,
+                                        "killedTasksSummary": {},
+                                        "name": "parquet at StringIndexer.scala:499",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 526,
-                                        "dataRead": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
                                         "rowCount": 1,
-                                        "jobId": 42,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
-                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:27.509GMT",
+                                        "stageIds": [
+                                            61
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:28.869GMT"
+                                    },
+                                    {
                                         "completionTime": "2023-05-08T07:03:28.174GMT",
-                                        "stageIds": [60],
-                                        "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
-                                        "numActiveTasks": 0,
-                                        "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
-                                        "numFailedTasks": 0,
-                                        "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
-                                        "numSkippedStages": 0,
-                                        "numFailedStages": 0,
-                                        "killedTasksSummary": {}
-                                    }, {
-                                        "dataWritten": 313,
                                         "dataRead": 0,
-                                        "rowCount": 1,
-                                        "jobId": 41,
-                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "dataWritten": 526,
                                         "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
-                                        "submissionTime": "2023-05-08T07:03:25.588GMT",
-                                        "completionTime": "2023-05-08T07:03:26.796GMT",
-                                        "stageIds": [59],
                                         "jobGroup": "14",
-                                        "status": "SUCCEEDED",
-                                        "numTasks": 1,
+                                        "jobId": 42,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
                                         "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
                                         "numCompletedTasks": 1,
-                                        "numSkippedTasks": 0,
+                                        "numFailedStages": 0,
                                         "numFailedTasks": 0,
                                         "numKilledTasks": 0,
-                                        "numCompletedIndices": 1,
-                                        "numActiveStages": 0,
-                                        "numCompletedStages": 1,
                                         "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            60
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:27.509GMT"
+                                    },
+                                    {
+                                        "completionTime": "2023-05-08T07:03:26.796GMT",
+                                        "dataRead": 0,
+                                        "dataWritten": 313,
+                                        "description": "Job group for statement 14:\n# Define Signature object \nsig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\nmodel_uri = register_spark_model(run = run,\n                                model = lg_model_tn, \n                                model_name = model_name, \n                                signature = sig_tn, \n                                metrics = lg_metricstn_dict, \n                                hyperparameters = TUNED_LGBM_PARAMS)\nmlflow.end_run()",
+                                        "jobGroup": "14",
+                                        "jobId": 41,
+                                        "killedTasksSummary": {},
+                                        "name": "runJob at SparkHadoopWriter.scala:85",
+                                        "numActiveStages": 0,
+                                        "numActiveTasks": 0,
+                                        "numCompletedIndices": 1,
+                                        "numCompletedStages": 1,
+                                        "numCompletedTasks": 1,
                                         "numFailedStages": 0,
-                                        "killedTasksSummary": {}
+                                        "numFailedTasks": 0,
+                                        "numKilledTasks": 0,
+                                        "numSkippedStages": 0,
+                                        "numSkippedTasks": 0,
+                                        "numTasks": 1,
+                                        "rowCount": 1,
+                                        "stageIds": [
+                                            59
+                                        ],
+                                        "status": "SUCCEEDED",
+                                        "submissionTime": "2023-05-08T07:03:25.588GMT"
                                     }
                                 ],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 9,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "b5b0b88e-08bb-4b98-8241-3708f0dd1322"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 14
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 14, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 14, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "name": "stderr",
-                    "text": ["/tmp/ipykernel_7705/1750966625.py:2: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.\n  sig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)),\n2023/05/08 07:03:45 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /tmp/tmpu6fqzas2/model, flavor: spark), fall back to return ['pyspark==3.3.1']. Set logging level to DEBUG to see the full traceback.\nSuccessfully registered model 'nyctaxi_tripduration_lightgbm'.\n2023/05/08 07:03:59 INFO mlflow.tracking._model_registry.client: Waiting up to 300 seconds for model version to finish creation.                     Model name: nyctaxi_tripduration_lightgbm, version 2\nCreated version '2' of model 'nyctaxi_tripduration_lightgbm'.\n"]
-                }, {
                     "output_type": "stream",
+                    "text": [
+                        "/tmp/ipykernel_7705/1750966625.py:2: UserWarning: Hint: Inferred schema contains integer column(s). Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more details.\n",
+                        "  sig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)),\n",
+                        "2023/05/08 07:03:45 WARNING mlflow.utils.environment: Encountered an unexpected error while inferring pip requirements (model URI: /tmp/tmpu6fqzas2/model, flavor: spark), fall back to return ['pyspark==3.3.1']. Set logging level to DEBUG to see the full traceback.\n",
+                        "Successfully registered model 'nyctaxi_tripduration_lightgbm'.\n",
+                        "2023/05/08 07:03:59 INFO mlflow.tracking._model_registry.client: Waiting up to 300 seconds for model version to finish creation.                     Model name: nyctaxi_tripduration_lightgbm, version 2\n",
+                        "Created version '2' of model 'nyctaxi_tripduration_lightgbm'.\n"
+                    ]
+                },
+                {
                     "name": "stdout",
-                    "text": ["Model saved in runb1bb91e0-55cf-4302-86d5-53b8aba63d13\nModel URI: runs:/b1bb91e0-55cf-4302-86d5-53b8aba63d13/nyctaxi_tripduration_lightgbm\n"]
+                    "output_type": "stream",
+                    "text": [
+                        "Model saved in runb1bb91e0-55cf-4302-86d5-53b8aba63d13\n",
+                        "Model URI: runs:/b1bb91e0-55cf-4302-86d5-53b8aba63d13/nyctaxi_tripduration_lightgbm\n"
+                    ]
                 }
             ],
-            "execution_count": 12,
-            "metadata": {}
-        }, {
+            "source": [
+                "# Define Signature object \n",
+                "sig_tn = ModelSignature(inputs=_infer_schema(train_df.select(categorical_features + numeric_features)), \n",
+                "                     outputs=_infer_schema(train_df.select(\"tripDuration\")))\n",
+                "\n",
+                "# Create a 'dict' object that contains values of metrics\n",
+                "lg_metricstn_dict = json.loads(lg_metrics_tn.toJSON().first())\n",
+                "\n",
+                "model_uri = register_spark_model(run = run,\n",
+                "                                model = lg_model_tn, \n",
+                "                                model_name = model_name, \n",
+                "                                signature = sig_tn, \n",
+                "                                metrics = lg_metricstn_dict, \n",
+                "                                hyperparameters = TUNED_LGBM_PARAMS)\n",
+                "mlflow.end_run()"
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["Note: if you do not see your model artifact in the workspace, please make sure to refresh your browser."],
             "metadata": {
                 "nteract": {
                     "transient": {
                         "deleting": false
                     }
                 }
-            }
-        }, {
+            },
+            "source": [
+                "Note: if you do not see your model artifact in the workspace, please make sure to refresh your browser."
+            ]
+        },
+        {
+            "attachments": {},
             "cell_type": "markdown",
-            "source": ["#### You will need the below run_uri to execute the next tutorial"],
-            "metadata": {}
-        }, {
+            "metadata": {},
+            "source": [
+                "#### You will need the below run_uri to execute the next tutorial"
+            ]
+        },
+        {
             "cell_type": "code",
-            "source": ["print(f\"Please copy this run_uri: {model_uri}\")"],
-            "outputs": [{
-                    "output_type": "display_data",
+            "execution_count": 13,
+            "metadata": {},
+            "outputs": [
+                {
                     "data": {
                         "application/vnd.livy.statement-meta+json": {
-                            "spark_pool": null,
-                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
-                            "statement_id": 15,
-                            "state": "finished",
-                            "livy_statement_state": "available",
-                            "queued_time": "2023-05-08T06:54:40.3986366Z",
-                            "session_start_time": null,
-                            "execution_start_time": "2023-05-08T07:04:03.6840866Z",
                             "execution_finish_time": "2023-05-08T07:04:04.0265972Z",
+                            "execution_start_time": "2023-05-08T07:04:03.6840866Z",
+                            "livy_statement_state": "available",
+                            "parent_msg_id": "27aaa131-cb6e-4068-a66c-28d64bc91b44",
+                            "queued_time": "2023-05-08T06:54:40.3986366Z",
+                            "session_id": "07c294f4-0823-4082-8017-42be47f9a7ac",
+                            "session_start_time": null,
                             "spark_jobs": {
-                                "numbers": {
-                                    "SUCCEEDED": 0,
-                                    "UNKNOWN": 0,
-                                    "RUNNING": 0,
-                                    "FAILED": 0
-                                },
                                 "jobs": [],
                                 "limit": 20,
+                                "numbers": {
+                                    "FAILED": 0,
+                                    "RUNNING": 0,
+                                    "SUCCEEDED": 0,
+                                    "UNKNOWN": 0
+                                },
                                 "rule": "ALL_DESC"
                             },
-                            "parent_msg_id": "27aaa131-cb6e-4068-a66c-28d64bc91b44"
+                            "spark_pool": null,
+                            "state": "finished",
+                            "statement_id": 15
                         },
-                        "text/plain": "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 15, Finished, Available)"
+                        "text/plain": [
+                            "StatementMeta(, 07c294f4-0823-4082-8017-42be47f9a7ac, 15, Finished, Available)"
+                        ]
                     },
-                    "metadata": {}
-                }, {
-                    "output_type": "stream",
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
                     "name": "stdout",
-                    "text": ["Please copy this run_uri: runs:/b1bb91e0-55cf-4302-86d5-53b8aba63d13/nyctaxi_tripduration_lightgbm\n"]
+                    "output_type": "stream",
+                    "text": [
+                        "Please copy this run_uri: runs:/b1bb91e0-55cf-4302-86d5-53b8aba63d13/nyctaxi_tripduration_lightgbm\n"
+                    ]
                 }
             ],
-            "execution_count": 13,
-            "metadata": {}
+            "source": [
+                "print(f\"Please copy this run_uri: {model_uri}\")"
+            ]
         }
     ],
     "metadata": {
-        "language_info": {
-            "name": "python"
-        },
-        "kernelspec": {
-            "name": "synapse_pyspark",
-            "display_name": "Synapse PySpark"
-        },
-        "widgets": {},
         "kernel_info": {
             "name": "synapse_pyspark"
         },
+        "kernelspec": {
+            "display_name": "Synapse PySpark",
+            "name": "synapse_pyspark"
+        },
+        "language_info": {
+            "name": "python"
+        },
+        "notebook_environment": {},
         "save_output": true,
         "spark_compute": {
             "compute_id": "/trident/default",
             "session_options": {
-                "enableDebugMode": false,
-                "conf": {}
+                "conf": {},
+                "enableDebugMode": false
             }
         },
-        "notebook_environment": {},
         "synapse_widget": {
-            "version": "0.1",
             "state": {
                 "11961b27-2c93-4331-9f4c-a53e994a9907": {
-                    "type": "Synapse.DataFrame",
+                    "persist_state": {
+                        "customOptions": {},
+                        "view": {
+                            "chartOptions": {
+                                "aggregationType": "sum",
+                                "binsNumber": 10,
+                                "categoryFieldKeys": [
+                                    "0"
+                                ],
+                                "chartType": "bar",
+                                "isStacked": false,
+                                "seriesFieldKeys": [
+                                    "0"
+                                ]
+                            },
+                            "tableOptions": {},
+                            "type": "details"
+                        }
+                    },
                     "sync_state": {
+                        "isSummary": false,
+                        "language": "scala",
                         "table": {
-                            "rows": [{
+                            "rows": [
+                                {
                                     "0": "25.36957482259526",
                                     "1": "5.036821897049295",
                                     "2": "0.7641619871170653",
@@ -1668,50 +2171,59 @@
                                     "index": 1
                                 }
                             ],
-                            "schema": [{
+                            "schema": [
+                                {
                                     "key": "0",
                                     "name": "mean_squared_error",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "1",
                                     "name": "root_mean_squared_error",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "2",
                                     "name": "R^2",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "3",
                                     "name": "mean_absolute_error",
                                     "type": "double"
                                 }
                             ],
                             "truncated": false
-                        },
-                        "isSummary": false,
-                        "language": "scala"
+                        }
                     },
-                    "persist_state": {
-                        "view": {
-                            "type": "details",
-                            "tableOptions": {},
-                            "chartOptions": {
-                                "chartType": "bar",
-                                "categoryFieldKeys": ["0"],
-                                "seriesFieldKeys": ["0"],
-                                "aggregationType": "sum",
-                                "isStacked": false,
-                                "binsNumber": 10
-                            }
-                        },
-                        "customOptions": {}
-                    }
+                    "type": "Synapse.DataFrame"
                 },
                 "838a4109-46a5-43e7-92c9-e60eb76d273f": {
-                    "type": "Synapse.DataFrame",
+                    "persist_state": {
+                        "customOptions": {},
+                        "view": {
+                            "chartOptions": {
+                                "aggregationType": "sum",
+                                "binsNumber": 10,
+                                "categoryFieldKeys": [
+                                    "0"
+                                ],
+                                "chartType": "bar",
+                                "isStacked": false,
+                                "seriesFieldKeys": [
+                                    "0"
+                                ]
+                            },
+                            "tableOptions": {},
+                            "type": "details"
+                        }
+                    },
                     "sync_state": {
+                        "isSummary": false,
+                        "language": "scala",
                         "table": {
-                            "rows": [{
+                            "rows": [
+                                {
                                     "0": "25.55949164306082",
                                     "1": "5.055639587931562",
                                     "2": "0.7623965020482438",
@@ -1719,55 +2231,37 @@
                                     "index": 1
                                 }
                             ],
-                            "schema": [{
+                            "schema": [
+                                {
                                     "key": "0",
                                     "name": "mean_squared_error",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "1",
                                     "name": "root_mean_squared_error",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "2",
                                     "name": "R^2",
                                     "type": "double"
-                                }, {
+                                },
+                                {
                                     "key": "3",
                                     "name": "mean_absolute_error",
                                     "type": "double"
                                 }
                             ],
                             "truncated": false
-                        },
-                        "isSummary": false,
-                        "language": "scala"
+                        }
                     },
-                    "persist_state": {
-                        "view": {
-                            "type": "details",
-                            "tableOptions": {},
-                            "chartOptions": {
-                                "chartType": "bar",
-                                "categoryFieldKeys": ["0"],
-                                "seriesFieldKeys": ["0"],
-                                "aggregationType": "sum",
-                                "isStacked": false,
-                                "binsNumber": 10
-                            }
-                        },
-                        "customOptions": {}
-                    }
+                    "type": "Synapse.DataFrame"
                 }
-            }
+            },
+            "version": "0.1"
         },
-        "trident": {
-            "lakehouse": {
-                "known_lakehouses": [{
-                        "id": "4fd9d516-62ef-4c40-9edf-b64bc782ca80"
-                    }
-                ]
-            }
-        }
+        "widgets": {}
     },
     "nbformat": 4,
     "nbformat_minor": 0

--- a/docs-samples/data-science/data-science-tutorial/05-perform-batch-scoring-and-save-predictions-to-lakehouse.ipynb
+++ b/docs-samples/data-science/data-science-tutorial/05-perform-batch-scoring-and-save-predictions-to-lakehouse.ipynb
@@ -1099,17 +1099,6 @@
         "synapse_widget": {
             "version": "0.1",
             "state": {}
-        },
-        "trident": {
-            "lakehouse": {
-                "default_lakehouse": "4fd9d516-62ef-4c40-9edf-b64bc782ca80",
-                "known_lakehouses": [{
-                        "id": "4fd9d516-62ef-4c40-9edf-b64bc782ca80"
-                    }
-                ],
-                "default_lakehouse_name": "DefaultLH",
-                "default_lakehouse_workspace_id": "c43639aa-073c-4b8b-987b-2110918da2c5"
-            }
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
All the existing notebooks had a trident section in them that referred to a known cluster and lakehouse.  This caused an odd experience when importing the notebooks, because it showed the guid of the workspace for the known cluster.   Removing section makes the import cleaner because it's more obvious the user must add a cluster.   Plus it aligns better with the published instructions in the fabric-samples repo.

Also in the file 04-train-and-track-machine-learning-models.ipynb there was a call to json.loads without a corresponding "import json"