### PR TITLE
Update 01 - Create Delta Tables.ipynb

### DIFF
--- a/docs-samples/data-engineering/Lakehouse Tutorial Source Code/01 - Create Delta Tables.ipynb
+++ b/docs-samples/data-engineering/Lakehouse Tutorial Source Code/01 - Create Delta Tables.ipynb
@@ -146,6 +146,7 @@
                 "\r\n",
                 "def loadFullDataFromSource(table_name):\r\n",
                 "    df = spark.read.format(\"parquet\").load('Files/wwi-raw-data/full/' + table_name)\r\n",
+                "    df = df.drop(\"Photo\")\r\n",
                 "    df.write.mode(\"overwrite\").format(\"delta\").save(\"Tables/\" + table_name)\r\n",
                 "\r\n",
                 "full_tables = [\r\n",


### PR DESCRIPTION
Step 13 at https://learn.microsoft.com/en-us/fabric/data-engineering/tutorial-lakehouse-data-preparation shows the dropping of the Photo column, but somehow it was removed from the notebook.

without this single line, the user running the tutorial will get an error stating that a Binary column (Photo) is not supported with DirectLake.