### PR TITLE
Fix great-expectations example by pinning version

### DIFF
--- a/docs-samples/data-science/semantic-link-samples/great_expectations_tutorial.ipynb
+++ b/docs-samples/data-science/semantic-link-samples/great_expectations_tutorial.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "# install libraries\n",
-    "%pip install semantic-link great-expectations great_expectations_experimental great_expectations_zipcode_expectations\n",
+    "%pip install semantic-link 'great-expectations<1.0' great_expectations_experimental great_expectations_zipcode_expectations\n",
     "\n",
     "# load %%dax cell magic\n",
     "%load_ext sempy"


### PR DESCRIPTION
The example expectation used in this notebook is not yet functional in the 1.0 version of `great-expectations`.

Users will need to use a `0.18.x` version.

If `semantic-link` uses a [constraints file](https://pip.pypa.io/en/stable/user_guide/#constraints-files), I would suggest adding this constraint as well.