### PR TITLE
Add service principal support for CI-CD samples

### DIFF
--- a/features-samples/fabric-apis/DeploymentPipelines-DeployAll.ps1
+++ b/features-samples/fabric-apis/DeploymentPipelines-DeployAll.ps1
@@ -22,6 +22,13 @@ $sourceStageName = "<SOURCE STAGE NAME>"                    # The name of the so
 $targetStageName = "<TARGET STAGE NAME>"                    # The name of the target stage
 $deploymentNote = "<DEPLOYMENT NOTE>"                       # The deployment note (Optional)
 
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
+
 # End Parameters =======================================
 
 $global:baseUrl = "<Base URL>" # Replace with environment-specific base URL. For example: "https://api.fabric.microsoft.com/v1"
@@ -31,16 +38,55 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
-    # Login to Azure
-    Connect-AzAccount | Out-Null
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
+
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetDeploymentPipelineByName($deploymentPipelineName) {
@@ -79,18 +125,26 @@ function GetDeploymentPipelineStageByName($deploymentPipelineStageName, $deploym
 
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
-        if (!$exception.Response) {
-            return $exception.Message
-        }
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse

--- a/features-samples/fabric-apis/DeploymentPipelines-SelectiveDeploy.ps1
+++ b/features-samples/fabric-apis/DeploymentPipelines-SelectiveDeploy.ps1
@@ -27,6 +27,13 @@ $sourceItem = @{
     itemType = "<SOURCE ITEM TYPE>"                         # The type of the item to be deployed (e.g. Dashboard)
 }
 
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
+
 # End Parameters =======================================
 
 $global:baseUrl = "<Base URL>" # Replace with environment-specific base URL. For example: "https://api.fabric.microsoft.com/v1"
@@ -36,16 +43,55 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
-    # Login to Azure
-    Connect-AzAccount | Out-Null
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
+
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetDeploymentPipelineByName($deploymentPipelineName) {
@@ -101,15 +147,26 @@ function GetDeploymentPipelineStageItemByName($itemName, $itemType, $deploymentP
 
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse

--- a/features-samples/git-integration/GitIntegration-CommitAll.ps1
+++ b/features-samples/git-integration/GitIntegration-CommitAll.ps1
@@ -18,6 +18,13 @@
 $workspaceName = "<WORKSPACE NAME>"      # The name of the workspace
 $commitMessage = "<COMMIT MESSAGE>"      # The commit message
 
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"
+$tenantId = "<TENANT ID>"
+$servicePrincipalSecret = "<SECRET VALUE>"
+
 # End Parameters =======================================
 
 $global:baseUrl = "<Base URL>" # Replace with environment-specific base URL. For example: "https://api.fabric.microsoft.com/v1"
@@ -27,22 +34,60 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    #Login to Azure
-    Connect-AzAccount | Out-Null
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetWorkspaceByName($workspaceName) {
     # Get workspaces    
-    $getWorkspacesUrl = "{0}/workspaces" -f $global:baseUrl
+    $getWorkspacesUrl = "$global:baseUrl/workspaces"
     $workspaces = (Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getWorkspacesUrl -Method GET).value
 
     # Try to find the workspace by display name
@@ -53,15 +98,26 @@ function GetWorkspaceByName($workspaceName) {
 
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse
@@ -81,7 +137,7 @@ try {
     # Commit to Git
     Write-Host "Committing all changes from workspace '$workspaceName' to Git."
 
-    $commitToGitUrl = "{0}/workspaces/{1}/git/commitToGit" -f $global:baseUrl, $workspace.Id
+    $commitToGitUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/commitToGit"
 
     $commitToGitBody = @{ 		
         mode = "All"

--- a/features-samples/git-integration/GitIntegration-CommitAll.ps1
+++ b/features-samples/git-integration/GitIntegration-CommitAll.ps1
@@ -21,9 +21,9 @@ $commitMessage = "<COMMIT MESSAGE>"      # The commit message
 $principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
 
 # Relevant for ServicePrincipal
-$clientId = "<CLIENT ID>"
-$tenantId = "<TENANT ID>"
-$servicePrincipalSecret = "<SECRET VALUE>"
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
 
 # End Parameters =======================================
 

--- a/features-samples/git-integration/GitIntegration-CommitSelective.ps1
+++ b/features-samples/git-integration/GitIntegration-CommitSelective.ps1
@@ -27,9 +27,9 @@ $reportsNames = @("<REPORT NAME>")        # The name of the reports to be commit
 $principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
 
 # Relevant for ServicePrincipal
-$clientId = "<CLIENT ID>"
-$tenantId = "<TENANT ID>"
-$servicePrincipalSecret = "<SECRET VALUE>"
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
 
 # End Parameters =======================================
 

--- a/features-samples/git-integration/GitIntegration-CommitSelective.ps1
+++ b/features-samples/git-integration/GitIntegration-CommitSelective.ps1
@@ -24,6 +24,13 @@ $datasetsNames = @("<DATASET NAME>")      # The names of the datasets to be comm
 
 $reportsNames = @("<REPORT NAME>")        # The name of the reports to be committed
 
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"
+$tenantId = "<TENANT ID>"
+$servicePrincipalSecret = "<SECRET VALUE>"
+
 # End Parameters =======================================
 
 $global:baseUrl = "<Base URL>" # Replace with environment-specific base URL. For example: "https://api.fabric.microsoft.com/v1"
@@ -33,22 +40,60 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    #Login to Azure
-    Connect-AzAccount | Out-Null
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetWorkspaceByName($workspaceName) {
     # Get workspaces    
-    $getWorkspacesUrl = "{0}/workspaces" -f $global:baseUrl
+    $getWorkspacesUrl = "$global:baseUrl/workspaces"
     $workspaces = (Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getWorkspacesUrl -Method GET).value
 
     # Try to find the workspace by display name
@@ -59,15 +104,26 @@ function GetWorkspaceByName($workspaceName) {
 
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse
@@ -98,7 +154,7 @@ try {
     # Get Status
     Write-Host "Calling GET Status REST API to construct the request body for CommitToGit REST API."
 
-    $gitStatusUrl = "{0}/workspaces/{1}/git/status" -f $global:baseUrl, $workspace.Id
+    $gitStatusUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/status"
     $gitStatusResponse = Invoke-RestMethod -Headers $global:fabricHeaders -Uri $gitStatusUrl -Method GET
     
     # Get selected changes
@@ -115,7 +171,7 @@ try {
     # Commit to Git
     Write-Host "Committing selected changes from workspace '$workspaceName' to Git."
 
-    $commitToGitUrl = "{0}/workspaces/{1}/git/commitToGit" -f $global:baseUrl, $workspace.Id
+    $commitToGitUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/commitToGit"
 
     $commitToGitBody = @{ 		
         mode = "Selective"

--- a/features-samples/git-integration/GitIntegration-ConnectAndUpdateFromGit.ps1
+++ b/features-samples/git-integration/GitIntegration-ConnectAndUpdateFromGit.ps1
@@ -48,9 +48,9 @@ $gitProviderDetails = @{} # Replace with specific Git provider, $azureDevOpsDeta
 $principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
 
 # Relevant for ServicePrincipal
-$clientId = "<CLIENT ID>"
-$tenantId = "<TENANT ID>"
-$servicePrincipalSecret = "<SECRET VALUE>"
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
 
 # End Parameters =======================================
 

--- a/features-samples/git-integration/GitIntegration-ConnectAndUpdateFromGit.ps1
+++ b/features-samples/git-integration/GitIntegration-ConnectAndUpdateFromGit.ps1
@@ -41,9 +41,16 @@ $gitHubDetails = @{
 }
 
 # Relevant for GitHub authentication
-$connectionId = "<CONNECTION ID>" # Replace with the connection Id that stores the gitProvider credentials (Required for GitHub)
+$connectionName = "<CONNECTION Name>" # Replace with the connection display name that stores the gitProvider credentials (Required for GitHub)
 
 $gitProviderDetails = @{} # Replace with specific Git provider, $azureDevOpsDetails or $gitHubDetails
+
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"
+$tenantId = "<TENANT ID>"
+$servicePrincipalSecret = "<SECRET VALUE>"
 
 # End Parameters =======================================
 
@@ -54,22 +61,60 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    #Login to Azure
-    Connect-AzAccount | Out-Null
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetWorkspaceByName($workspaceName) {
     # Get workspaces    
-    $getWorkspacesUrl = "{0}/workspaces" -f $global:baseUrl
+    $getWorkspacesUrl = "$global:baseUrl/workspaces"
     $workspaces = (Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getWorkspacesUrl -Method GET).value
 
     # Try to find the workspace by display name
@@ -78,17 +123,39 @@ function GetWorkspaceByName($workspaceName) {
     return $workspace
 }
 
+function GetConnectionByName($connectionName) {
+    # Get workspaces    
+    $getConnectionsUrl = "$global:baseUrl/connections"
+    $connections = (Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getConnectionsUrl -Method GET).value
+
+    # Try to find the connection by display name
+    $connection = $connections | Where-Object {$_.DisplayName -eq $connectionName}
+
+    return $connection
+}
+
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse
@@ -110,7 +177,7 @@ try {
         # Disconnect from Git
         Write-Host "Disconnecting the workspace '$workspaceName' from Git."
 
-        $disconnectUrl = "{0}/workspaces/{1}/git/disconnect" -f $global:baseUrl, $workspace.Id
+        $disconnectUrl = "$global:baseUrl/workspaces/$workspace.Id/git/disconnect"
         Invoke-RestMethod -Headers $global:fabricHeaders -Uri $disconnectUrl -Method POST
 
         Write-Host "The workspace '$workspaceName' has been successfully disconnected from Git." -ForegroundColor Green
@@ -119,7 +186,7 @@ try {
     # Connect to Git
     Write-Host "Connecting the workspace '$workspaceName' to Git."
 
-    $connectUrl = "{0}/workspaces/{1}/git/connect" -f $global:baseUrl, $workspace.Id
+    $connectUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/connect"
     
     $connectToGitBody = @{}
 
@@ -130,15 +197,24 @@ try {
     }
 
     if ($gitProviderDetails.GitProviderType -eq "GitHub") {
+        
+        $connection = GetConnectionByName $connectionName
+
+        # Verify the existence of the requested connection
+    	if(!$connection) {
+    	  Write-Host "A connection with the requested name was not found." -ForegroundColor Red
+    	  return
+    	}
+
         $connectToGitBody = @{
             gitProviderDetails = $gitProviderDetails
             myGitCredentials = @{
                 source = "ConfiguredConnection"
-                connectionId = $connectionId
+                connectionId = $connection.id
             }
         } | ConvertTo-Json
     }
-        
+   
     Invoke-RestMethod -Headers $global:fabricHeaders -Uri $connectUrl -Method POST -Body $connectToGitBody
 
     Write-Host "The workspace '$workspaceName' has been successfully connected to Git." -ForegroundColor Green
@@ -146,8 +222,8 @@ try {
     # Initialize Connection
     Write-Host "Initializing Git connection for workspace '$workspaceName'."
 
-    $initializeConnectionUrl = "{0}/workspaces/{1}/git/initializeConnection" -f $global:baseUrl, $workspace.Id
-    $initializeConnectionResponse = Invoke-RestMethod -Headers $global:fabricHeaders -Uri $initializeConnectionUrl -Method POST -Body "{}"
+    $initializeConnectionUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/initializeConnection"
+    $initializeConnectionResponse = Invoke-RestMethod -Headers $global:fabricHeaders -Uri $initializeConnectionUrl -Method POST
 
     Write-Host "The Git connection for workspace '$workspaceName' has been successfully initialized." -ForegroundColor Green
 
@@ -156,7 +232,7 @@ try {
         # Update from Git
         Write-Host "Updating the workspace '$workspaceName' from Git."
 
-        $updateFromGitUrl = "{0}/workspaces/{1}/git/updateFromGit" -f $global:baseUrl, $workspace.Id
+        $updateFromGitUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/updateFromGit"
 
         $updateFromGitBody = @{ 
             remoteCommitHash = $initializeConnectionResponse.RemoteCommitHash
@@ -170,7 +246,7 @@ try {
         Write-Host "Long Running Operation ID: '$operationId' has been scheduled for updating the workspace '$workspaceName' from Git with a retry-after time of '$retryAfter' seconds." -ForegroundColor Green
         
         # Poll Long Running Operation
-        $getOperationState = "{0}/operations/{1}" -f $global:baseUrl, $operationId
+        $getOperationState = "$global:baseUrl/operations/$operationId"
         do
         {
             $operationState = Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getOperationState -Method GET

--- a/features-samples/git-integration/GitIntegration-UpdateMyGitCredentials.ps1
+++ b/features-samples/git-integration/GitIntegration-UpdateMyGitCredentials.ps1
@@ -37,9 +37,9 @@ $myGitCredentials = @{} # <Replace with $configuredConnectionGitCredentials or $
 $principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
 
 # Relevant for ServicePrincipal
-$clientId = "<CLIENT ID>"
-$tenantId = "<TENANT ID>"
-$servicePrincipalSecret = "<SECRET VALUE>"
+$clientId = "<CLIENT ID>"                   #The application (client) ID of the service principal
+$tenantId = "<TENANT ID>"                   #The directory (tenant) ID of the service principal
+$servicePrincipalSecret = "<SECRET VALUE>"  #The secret value of the service principal
 
 # End Parameters =======================================
 

--- a/features-samples/git-integration/GitIntegration-UpdateMyGitCredentials.ps1
+++ b/features-samples/git-integration/GitIntegration-UpdateMyGitCredentials.ps1
@@ -34,6 +34,13 @@ $noneGitCredentials = @{
 
 $myGitCredentials = @{} # <Replace with $configuredConnectionGitCredentials or $automaticGitCredentials or $noneGitCredentials>
 
+$principalType = "<PRINCIPAL TYPE>" # Choose either "UserPrincipal" or "ServicePrincipal"
+
+# Relevant for ServicePrincipal
+$clientId = "<CLIENT ID>"
+$tenantId = "<TENANT ID>"
+$servicePrincipalSecret = "<SECRET VALUE>"
+
 # End Parameters =======================================
 
 $global:baseUrl = "<Base URL>" # Replace with environment-specific base URL. For example: "https://api.fabric.microsoft.com/v1"
@@ -43,22 +50,60 @@ $global:resourceUrl = "https://api.fabric.microsoft.com"
 $global:fabricHeaders = @{}
 
 function SetFabricHeaders() {
+    if ($principalType -eq "UserPrincipal") {
+        $secureFabricToken = GetSecureTokenForUserPrincipal
+    } elseif ($principalType -eq "ServicePrincipal") {
+        $secureFabricToken = GetSecureTokenForServicePrincipal
 
-    #Login to Azure
-    Connect-AzAccount | Out-Null
+    } else {
+        throw "Invalid principal type. Please choose either 'UserPrincipal' or 'ServicePrincipal'."
+    }
 
-    # Get authentication
-    $fabricToken = (Get-AzAccessToken -ResourceUrl $global:resourceUrl).Token
+    # Convert SecureString to plain text
+    $fabricToken = ConvertSecureStringToPlainText($secureFabricToken)
 
     $global:fabricHeaders = @{
         'Content-Type' = "application/json"
-        'Authorization' = "Bearer {0}" -f $fabricToken
+        'Authorization' = "Bearer $fabricToken"
     }
+}
+
+function GetSecureTokenForUserPrincipal() {
+    #Login to Azure interactively
+    Connect-AzAccount | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+
+    return $secureFabricToken
+}
+
+function GetSecureTokenForServicePrincipal() {
+    $secureServicePrincipalSecret  = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+    $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $secureServicePrincipalSecret
+
+    #Login to Azure using service principal
+    Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+
+    # Get authentication
+    $secureFabricToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $global:resourceUrl).Token
+    
+    return $secureFabricToken
+}
+
+function ConvertSecureStringToPlainText($secureString) {
+    $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureString)
+    try {
+        $plainText = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+    }
+    return $plainText
 }
 
 function GetWorkspaceByName($workspaceName) {
     # Get workspaces    
-    $getWorkspacesUrl = "{0}/workspaces" -f $global:baseUrl
+    $getWorkspacesUrl = "$global:baseUrl/workspaces"
     $workspaces = (Invoke-RestMethod -Headers $global:fabricHeaders -Uri $getWorkspacesUrl -Method GET).value
 
     # Try to find the workspace by display name
@@ -69,15 +114,26 @@ function GetWorkspaceByName($workspaceName) {
 
 function GetErrorResponse($exception) {
     # Relevant only for PowerShell Core
-    $errorResponse = $_.ErrorDetails.Message
+    # Try to fill based on ErrorDetails.Message
+    $errorResponse = $exception.ErrorDetails.Message
 
+    # If still null, try based on exception.Message
     if(!$errorResponse) {
-        # This is needed to support Windows PowerShell
+        $errorResponse = $exception.Message
+    }
+
+    # If still null and exception.Response isn't null, try to read the response stream and fill in
+    if(!$errorResponse -and $exception.Response) {
         $result = $exception.Response.GetResponseStream()
         $reader = New-Object System.IO.StreamReader($result)
         $reader.BaseStream.Position = 0
         $reader.DiscardBufferedData()
-        $errorResponse = $reader.ReadToEnd();
+        $errorResponse = $reader.ReadToEnd()
+    }
+
+    # If all else fails, fill in generic error
+    if(!$errorResponse) {
+        $errorResponse = "An error occurred, but no detailed message is available."
     }
 
     return $errorResponse
@@ -97,7 +153,7 @@ try {
     # Update Git Credentials
     Write-Host "Updating the Git credentials for the current user in the workspace '$workspaceName'."
 
-    $updateMyGitCredentialsUrl = "{0}/workspaces/{1}/git/myGitCredentials" -f $global:baseUrl, $workspace.Id
+    $updateMyGitCredentialsUrl = "$global:baseUrl/workspaces/$($workspace.Id)/git/myGitCredentials"
 
     $updateMyGitCredentialsBody = $myGitCredentials | ConvertTo-Json
 


### PR DESCRIPTION
1. Support service principal in GitIntegration and Deployment Pipelines' scripts
2. Update the scripts to use AsSecureString to avoid the upcoming breaking change
3. Improve error parsing
4. Add script for StoringGitProviderCredentials